### PR TITLE
Company CRUD, molds-by-company endpoint, and form style unification

### DIFF
--- a/deploy/backend/migrations/20260506100000-create-companies.js
+++ b/deploy/backend/migrations/20260506100000-create-companies.js
@@ -1,0 +1,28 @@
+"use strict";
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterfaceOrObject, Sequelize) {
+    const queryInterface = queryInterfaceOrObject?.context ?? queryInterfaceOrObject;
+    await queryInterface.createTable("Companies", {
+      id: { type: Sequelize.UUID, defaultValue: Sequelize.UUIDV4, allowNull: false, primaryKey: true },
+      name: { type: Sequelize.STRING(255), allowNull: false },
+      pib: { type: Sequelize.STRING(20), allowNull: false, unique: true },
+      mb: { type: Sequelize.STRING(20), allowNull: false, unique: true },
+      address: { type: Sequelize.STRING(255), allowNull: true },
+      phones: { type: Sequelize.JSONB, allowNull: false, defaultValue: [] },
+      emails: { type: Sequelize.JSONB, allowNull: false, defaultValue: [] },
+      ownerInfo: { type: Sequelize.STRING(255), allowNull: true },
+      representative: { type: Sequelize.STRING(255), allowNull: true },
+      isOwnCompany: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+      isCustomer: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+      isSupplier: { type: Sequelize.BOOLEAN, allowNull: false, defaultValue: false },
+      notes: { type: Sequelize.TEXT, allowNull: true },
+      createdAt: { allowNull: false, type: Sequelize.DATE, defaultValue: Sequelize.literal("CURRENT_TIMESTAMP") },
+      updatedAt: { allowNull: false, type: Sequelize.DATE, defaultValue: Sequelize.literal("CURRENT_TIMESTAMP") },
+    });
+  },
+  async down(queryInterfaceOrObject) {
+    const queryInterface = queryInterfaceOrObject?.context ?? queryInterfaceOrObject;
+    await queryInterface.dropTable("Companies");
+  },
+};

--- a/deploy/backend/migrations/20260506110000-add-owned-by-to-molds.js
+++ b/deploy/backend/migrations/20260506110000-add-owned-by-to-molds.js
@@ -1,0 +1,18 @@
+"use strict";
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterfaceOrObject, Sequelize) {
+    const queryInterface = queryInterfaceOrObject?.context ?? queryInterfaceOrObject;
+    await queryInterface.addColumn("Molds", "ownedByCompanyId", {
+      type: Sequelize.UUID,
+      allowNull: true,
+      references: { model: "Companies", key: "id" },
+      onUpdate: "CASCADE",
+      onDelete: "SET NULL",
+    });
+  },
+  async down(queryInterfaceOrObject) {
+    const queryInterface = queryInterfaceOrObject?.context ?? queryInterfaceOrObject;
+    await queryInterface.removeColumn("Molds", "ownedByCompanyId");
+  },
+};

--- a/deploy/backend/migrations/20260506130000-add-logo-to-companies.js
+++ b/deploy/backend/migrations/20260506130000-add-logo-to-companies.js
@@ -1,0 +1,16 @@
+"use strict";
+
+module.exports = {
+  up: async (queryInterfaceOrObject, DataTypes) => {
+    const queryInterface = queryInterfaceOrObject?.context ?? queryInterfaceOrObject;
+    await queryInterface.addColumn("Companies", "logo", {
+      type: DataTypes.STRING,
+      allowNull: true,
+      defaultValue: null,
+    });
+  },
+  down: async (queryInterfaceOrObject) => {
+    const queryInterface = queryInterfaceOrObject?.context ?? queryInterfaceOrObject;
+    await queryInterface.removeColumn("Companies", "logo");
+  },
+};

--- a/deploy/backend/seeders/20260506120000-seed-companies.js
+++ b/deploy/backend/seeders/20260506120000-seed-companies.js
@@ -1,0 +1,70 @@
+"use strict";
+
+const { randomUUID } = require("crypto");
+
+/** @type {import('sequelize-cli').Seeder} */
+module.exports = {
+  async up(queryInterface) {
+    const now = new Date();
+
+    await queryInterface.bulkInsert("Companies", [
+      {
+        id: randomUUID(),
+        name: "SZR SIMIL ILIĆ MIROSLAV PREDUZETNIK",
+        pib: "102867025",
+        mb: "55947139",
+        address: "Valjevo",
+        phones: JSON.stringify(["014215510", "014215754", "0638597843", "0641357392"]),
+        emails: JSON.stringify([{ address: "similoffice@gmail.com", isPrimary: true }]),
+        ownerInfo: "Miroslav Ilić (100,00%)",
+        representative: "Miroslav Ilić, Direktor",
+        isOwnCompany: true,
+        isCustomer: false,
+        isSupplier: false,
+        notes: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: randomUUID(),
+        name: "Gorenje d.o.o.",
+        pib: "100000001",
+        mb: "10000001",
+        address: null,
+        phones: JSON.stringify([]),
+        emails: JSON.stringify([]),
+        ownerInfo: null,
+        representative: null,
+        isOwnCompany: false,
+        isCustomer: true,
+        isSupplier: false,
+        notes: "Vlasnik određenih kalupa u fabrici",
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: randomUUID(),
+        name: "Hisense Group Co. Ltd.",
+        pib: "100000002",
+        mb: "10000002",
+        address: null,
+        phones: JSON.stringify([]),
+        emails: JSON.stringify([]),
+        ownerInfo: null,
+        representative: null,
+        isOwnCompany: false,
+        isCustomer: true,
+        isSupplier: false,
+        notes: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.bulkDelete("Companies", {
+      pib: ["102867025", "100000001", "100000002"],
+    });
+  },
+};

--- a/deploy/backend/src/controllers/company.controller.ts
+++ b/deploy/backend/src/controllers/company.controller.ts
@@ -1,0 +1,61 @@
+import { Request, Response } from "express";
+import path from "path";
+import fs from "fs";
+import httpStatus from "http-status";
+
+import { companyService } from "../service";
+import { catchAsync } from "../shared/utils/CatchAsync";
+
+export const getAllCompanies = catchAsync(async (req: Request, res: Response) => {
+  const page = parseInt(String(req.query.page ?? "1"), 10);
+  const limit = parseInt(String(req.query.limit ?? "50"), 10);
+  const search = String(req.query.search ?? "");
+  const offset = (page - 1) * limit;
+  const { rows, total } = await companyService.getAllCompanies(search, limit, offset);
+  res.status(httpStatus.OK).send({ success: true, message: "OK", content: { companies: rows, pagination: { total, page, limit } } });
+});
+
+export const getAllCompaniesList = catchAsync(async (_req: Request, res: Response) => {
+  const companies = await companyService.getAllCompaniesList();
+  res.status(httpStatus.OK).send({ success: true, message: "OK", content: { companies } });
+});
+
+export const getCompanyById = catchAsync(async (req: Request, res: Response) => {
+  const company = await companyService.getCompanyById(req.params.id);
+  res.status(httpStatus.OK).send({ success: true, message: "OK", content: { company } });
+});
+
+export const createCompany = catchAsync(async (req: Request, res: Response) => {
+  const company = await companyService.createCompany(req.body);
+  res.status(httpStatus.OK).send({ success: true, message: "Company created successfully!", content: { company } });
+});
+
+export const updateCompany = catchAsync(async (req: Request, res: Response) => {
+  const company = await companyService.updateCompany({ ...req.body, id: req.params.id });
+  res.status(httpStatus.OK).send({ success: true, message: "Company updated successfully!", content: { company } });
+});
+
+export const deleteCompany = catchAsync(async (req: Request, res: Response) => {
+  const deleted = await companyService.deleteCompany(req.params.id);
+  res.status(httpStatus.OK).send({ success: true, message: "Company deleted successfully!", content: { deleted } });
+});
+
+export const uploadCompanyLogo = (req: Request, res: Response) => {
+  if (!req.file) return res.status(400).json({ success: false, error: "No file uploaded" });
+  const logoPath = `/uploads/temp/${req.file.filename}`;
+  return res.status(200).json({ success: true, path: logoPath });
+};
+
+export const deleteCompanyLogo = catchAsync(async (req: Request, res: Response) => {
+  const company = await companyService.getCompanyById(req.params.id);
+  if (company.logo) {
+    const fileName = company.logo.replace("/uploads/temp/", "").replace("/uploads/", "");
+    const uploadsDir = path.join(__dirname, "../uploads");
+    const filePath = path.join(uploadsDir, fileName);
+    if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+    const tempPath = path.join(uploadsDir, "temp", fileName);
+    if (fs.existsSync(tempPath)) fs.unlinkSync(tempPath);
+  }
+  const updated = await companyService.updateCompany({ ...company, logo: null });
+  res.status(httpStatus.OK).send({ success: true, message: "Logo removed.", content: { company: updated } });
+});

--- a/deploy/backend/src/controllers/index.ts
+++ b/deploy/backend/src/controllers/index.ts
@@ -19,3 +19,4 @@ export * as itemController from "./item.controller";
 export * as bomLineController from "./bomLine.controller";
 export * as packagingUnitController from "./packagingUnit.controller";
 export * as itemPackagingController from "./itemPackaging.controller";
+export * as companyController from "./company.controller";

--- a/deploy/backend/src/controllers/mold.controller.ts
+++ b/deploy/backend/src/controllers/mold.controller.ts
@@ -55,6 +55,15 @@ export const updateMold = catchAsync(async (req: Request, res: Response) => {
   return res.status(httpStatus.OK).send({ success: true, message: "Successfully updated mold!", content: { mold } });
 });
 
+export const getMoldsByCompany = catchAsync(async (req: Request, res: Response) => {
+  const { companyId } = req.params;
+  if (!companyId) {
+    return res.status(httpStatus.BAD_REQUEST).send({ success: false, message: "Missing company ID." });
+  }
+  const molds = await moldService.getMoldsByCompanyId(companyId);
+  return res.status(httpStatus.OK).send({ success: true, message: "OK", content: { molds } });
+});
+
 export const getMoldMountedOnMachine = catchAsync(async (req: Request, res: Response) => {
   const { machineId } = req.params;
   if (!machineId) {

--- a/deploy/backend/src/models/company.model.ts
+++ b/deploy/backend/src/models/company.model.ts
@@ -1,0 +1,67 @@
+import { Company, CreateCompanyData, EditCompanyData } from "../service/company.service.types";
+import { callQuery } from "./utils/query";
+
+export const getAllCompaniesQuery = async (
+  search: string, limit: number, offset: number
+): Promise<{ rows: Company[]; total: number }> => {
+  const param = `%${search}%`;
+  const [rows, counts] = await Promise.all([
+    callQuery<Company[]>(
+      `SELECT * FROM "Companies"
+       WHERE "name" ILIKE $1 OR "pib" ILIKE $1 OR "mb" ILIKE $1
+       ORDER BY "name" ASC LIMIT $2 OFFSET $3`,
+      [param, limit, offset], true
+    ),
+    callQuery<{ count: string }[]>(
+      `SELECT COUNT(*) FROM "Companies"
+       WHERE "name" ILIKE $1 OR "pib" ILIKE $1 OR "mb" ILIKE $1`,
+      [param], true
+    ),
+  ]);
+  return { rows: rows ?? [], total: parseInt(counts?.[0]?.count ?? "0", 10) };
+};
+
+export const getCompanyByIdQuery = async (id: string): Promise<Company> =>
+  callQuery<Company>(`SELECT * FROM "Companies" WHERE "id" = $1`, [id]);
+
+export const getAllCompaniesListQuery = async (): Promise<Pick<Company, "id" | "name">[]> =>
+  callQuery<Pick<Company, "id" | "name">[]>(
+    `SELECT "id", "name" FROM "Companies" ORDER BY "name" ASC`, [], true
+  );
+
+export const createCompanyQuery = async (data: CreateCompanyData): Promise<Company> =>
+  callQuery<Company>(
+    `INSERT INTO "Companies"
+       ("id", "name", "pib", "mb", "address", "phones", "emails",
+        "ownerInfo", "representative", "isOwnCompany", "isCustomer", "isSupplier", "notes", "logo",
+        "createdAt", "updatedAt")
+     VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW(), NOW())
+     RETURNING *`,
+    [
+      data.name, data.pib, data.mb, data.address ?? null,
+      JSON.stringify(data.phones), JSON.stringify(data.emails),
+      data.ownerInfo ?? null, data.representative ?? null,
+      data.isOwnCompany, data.isCustomer, data.isSupplier,
+      data.notes ?? null, data.logo ?? null,
+    ]
+  );
+
+export const updateCompanyQuery = async (data: EditCompanyData): Promise<Company> =>
+  callQuery<Company>(
+    `UPDATE "Companies" SET
+       "name" = $1, "pib" = $2, "mb" = $3, "address" = $4,
+       "phones" = $5, "emails" = $6, "ownerInfo" = $7, "representative" = $8,
+       "isOwnCompany" = $9, "isCustomer" = $10, "isSupplier" = $11,
+       "notes" = $12, "logo" = $13, "updatedAt" = NOW()
+     WHERE "id" = $14 RETURNING *`,
+    [
+      data.name, data.pib, data.mb, data.address ?? null,
+      JSON.stringify(data.phones), JSON.stringify(data.emails),
+      data.ownerInfo ?? null, data.representative ?? null,
+      data.isOwnCompany, data.isCustomer, data.isSupplier,
+      data.notes ?? null, data.logo ?? null, data.id,
+    ]
+  );
+
+export const deleteCompanyQuery = async (id: string): Promise<Company> =>
+  callQuery<Company>(`DELETE FROM "Companies" WHERE "id" = $1 RETURNING *`, [id]);

--- a/deploy/backend/src/models/mold.model.ts
+++ b/deploy/backend/src/models/mold.model.ts
@@ -32,9 +32,11 @@ export const getTotalMoldsCountQuery = async (search: string): Promise<number> =
 
 export const getMoldByIdQuery = async (id: string): Promise<Mold> => {
   const sql = `
-    SELECT m.*, mac."name" AS "currentMachineName", mac."machineNumber" AS "currentMachineNumber"
+    SELECT m.*, mac."name" AS "currentMachineName", mac."machineNumber" AS "currentMachineNumber",
+           c."name" AS "ownedByCompanyName"
     FROM "Molds" m
     LEFT JOIN "Machines" mac ON mac."id" = m."currentMachineId"
+    LEFT JOIN "Companies" c ON c."id" = m."ownedByCompanyId"
     WHERE m."id" = $1
   `;
   return callQuery<Mold>(sql, [id]);
@@ -42,9 +44,11 @@ export const getMoldByIdQuery = async (id: string): Promise<Mold> => {
 
 export const getMoldMountedOnMachineQuery = async (machineId: string): Promise<Mold | null> => {
   const sql = `
-    SELECT m.*, mac."name" AS "currentMachineName", mac."machineNumber" AS "currentMachineNumber"
+    SELECT m.*, mac."name" AS "currentMachineName", mac."machineNumber" AS "currentMachineNumber",
+           c."name" AS "ownedByCompanyName"
     FROM "Molds" m
     LEFT JOIN "Machines" mac ON mac."id" = m."currentMachineId"
+    LEFT JOIN "Companies" c ON c."id" = m."ownedByCompanyId"
     WHERE m."currentMachineId" = $1
     LIMIT 1
   `;
@@ -58,12 +62,12 @@ export const createMoldQuery = async (data: CreateMoldData): Promise<Mold> => {
       ("id", "inventoryNumber", "name", "cavities", "requiredClampingForceKN",
        "heightMM", "widthMM", "depthMM", "centeringDiameterMM", "temperingTemperatures",
        "weight", "pictures", "documents", "status", "pieceCounter", "serviceCategory", "notes",
-       "currentMachineId", "createdAt", "updatedAt")
+       "currentMachineId", "ownedByCompanyId", "createdAt", "updatedAt")
     VALUES (
       gen_random_uuid(), $1, $2, $3, $4,
       $5, $6, $7, $8, $9::jsonb,
       $10, $11::jsonb, $12::jsonb, $13, $14, $15, $16,
-      $17, NOW(), NOW()
+      $17, $18, NOW(), NOW()
     )
     RETURNING *
   `;
@@ -85,6 +89,7 @@ export const createMoldQuery = async (data: CreateMoldData): Promise<Mold> => {
     data.serviceCategory ?? null,
     data.notes ?? null,
     data.currentMachineId ?? null,
+    data.ownedByCompanyId ?? null,
   ]);
 };
 
@@ -109,8 +114,9 @@ export const updateMoldQuery = async (data: EditMoldData): Promise<Mold> => {
       "serviceCategory"        = $15,
       "notes"                  = $16,
       "currentMachineId"       = $17,
+      "ownedByCompanyId"       = $18,
       "updatedAt"              = NOW()
-    WHERE "id" = $18
+    WHERE "id" = $19
     RETURNING *
   `;
   return callQuery<Mold>(sql, [
@@ -131,6 +137,7 @@ export const updateMoldQuery = async (data: EditMoldData): Promise<Mold> => {
     data.serviceCategory ?? null,
     data.notes ?? null,
     data.currentMachineId ?? null,
+    data.ownedByCompanyId ?? null,
     data.id,
   ]);
 };
@@ -138,6 +145,19 @@ export const updateMoldQuery = async (data: EditMoldData): Promise<Mold> => {
 export const deleteMoldQuery = async (id: string): Promise<Mold> => {
   const sql = `DELETE FROM "Molds" WHERE "id" = $1 RETURNING *`;
   return callQuery<Mold>(sql, [id]);
+};
+
+export const getMoldsByCompanyIdQuery = async (companyId: string): Promise<Mold[]> => {
+  const sql = `
+    SELECT m.*, mac."name" AS "currentMachineName", mac."machineNumber" AS "currentMachineNumber",
+           c."name" AS "ownedByCompanyName"
+    FROM "Molds" m
+    LEFT JOIN "Machines" mac ON mac."id" = m."currentMachineId"
+    LEFT JOIN "Companies" c ON c."id" = m."ownedByCompanyId"
+    WHERE m."ownedByCompanyId" = $1
+    ORDER BY m."inventoryNumber" ASC
+  `;
+  return callQuery<Mold[]>(sql, [companyId], true) || [];
 };
 
 export const checkInventoryNumberExistsQuery = async (

--- a/deploy/backend/src/models/utils/query.ts
+++ b/deploy/backend/src/models/utils/query.ts
@@ -19,7 +19,8 @@ export const callQuery = async <T>(
     return getAll ? result.rows : result.rows[0];
   } catch (error) {
     logger.error(error);
-    throw new DBError(error);
+    const message = error instanceof Error ? error.message : String(error);
+    throw new DBError(message);
   } finally {
     if (client) {
       client.release();

--- a/deploy/backend/src/routes/api/company.route.ts
+++ b/deploy/backend/src/routes/api/company.route.ts
@@ -1,0 +1,20 @@
+import { RequestHandler, Router } from "express";
+
+import { companyController } from "../../controllers";
+import { upload } from "../../config/multerConfig";
+import { validateRequestBody } from "../../middlewares/requestValidation";
+import { authorizeAdmin, authorizeModerator, verifyTokenMiddleware } from "../../middlewares/verifyTokenMiddleware";
+import { CreateCompanySchema, UpdateCompanySchema } from "../../shared/joi/company.schema";
+
+export const companyRouter = Router();
+
+companyRouter.use(verifyTokenMiddleware);
+
+companyRouter.route("/").get(companyController.getAllCompanies);
+companyRouter.route("/list").get(companyController.getAllCompaniesList);
+companyRouter.route("/upload-logo").post(upload.single("logo") as unknown as RequestHandler, companyController.uploadCompanyLogo);
+companyRouter.route("/:id").get(companyController.getCompanyById);
+companyRouter.route("/:id/delete-logo").delete(authorizeAdmin, companyController.deleteCompanyLogo);
+companyRouter.route("/create").post(validateRequestBody(CreateCompanySchema), authorizeAdmin, companyController.createCompany);
+companyRouter.route("/update/:id").put(validateRequestBody(UpdateCompanySchema), authorizeAdmin, companyController.updateCompany);
+companyRouter.route("/delete/:id").delete(authorizeModerator, companyController.deleteCompany);

--- a/deploy/backend/src/routes/api/index.ts
+++ b/deploy/backend/src/routes/api/index.ts
@@ -11,6 +11,7 @@ import { moldRouter } from "./mold.route";
 import { moldMachineCompatibilityRouter } from "./moldMachineCompatibility.route";
 import { itemRouter } from "./item.route";
 import { packagingUnitRouter } from "./packagingUnit.route";
+import { companyRouter } from "./company.route";
 import { jobPositionRouter } from "./jobPosition.route";
 import { jobPositionCategoryRouter } from "./jobPositionCategory.route";
 import { machineAvailabilityStatusRouter } from "./machineAvailabilityStatus.router";
@@ -103,6 +104,10 @@ const defaultRoutes: RouteDefinition[] = [
   {
     path: "/packaging-unit",
     route: packagingUnitRouter,
+  },
+  {
+    path: "/company",
+    route: companyRouter,
   },
 ];
 

--- a/deploy/backend/src/routes/api/mold.route.ts
+++ b/deploy/backend/src/routes/api/mold.route.ts
@@ -15,6 +15,7 @@ moldRouter.use(verifyTokenMiddleware);
 
 moldRouter.route("/").get(moldController.getAllMolds);
 moldRouter.route("/mounted-on/:machineId").get(moldController.getMoldMountedOnMachine);
+moldRouter.route("/by-company/:companyId").get(moldController.getMoldsByCompany);
 moldRouter.route("/:id").get(moldController.getMoldById);
 moldRouter.route("/create").post(validateRequestBody(CreateMoldSchema), authorizeAdmin, moldController.createMold);
 moldRouter.route("/update/:id").put(validateRequestBody(UpdateMoldSchema), authorizeAdmin, moldController.updateMold);

--- a/deploy/backend/src/service/company.service.ts
+++ b/deploy/backend/src/service/company.service.ts
@@ -1,0 +1,78 @@
+import httpStatus from "http-status";
+
+import {
+  createCompanyQuery,
+  deleteCompanyQuery,
+  getAllCompaniesListQuery,
+  getAllCompaniesQuery,
+  getCompanyByIdQuery,
+  updateCompanyQuery,
+} from "../models/company.model";
+import { ApiError } from "../shared/error/ApiError";
+import { Company, CreateCompanyData, EditCompanyData } from "./company.service.types";
+
+export const getAllCompanies = async (search: string, limit: number, offset: number) => {
+  try {
+    return await getAllCompaniesQuery(search, limit, offset);
+  } catch (error) {
+    throw new ApiError("Error fetching companies!", httpStatus.INTERNAL_SERVER_ERROR);
+  }
+};
+
+export const getAllCompaniesList = async (): Promise<Pick<Company, "id" | "name">[]> => {
+  try {
+    return await getAllCompaniesListQuery();
+  } catch (error) {
+    throw new ApiError("Error fetching companies list!", httpStatus.INTERNAL_SERVER_ERROR);
+  }
+};
+
+export const getCompanyById = async (id: string): Promise<Company> => {
+  try {
+    const company = await getCompanyByIdQuery(id);
+    if (!company) throw new ApiError("Company not found.", httpStatus.NOT_FOUND);
+    return company;
+  } catch (error) {
+    if (error instanceof ApiError) throw error;
+    throw new ApiError("Error fetching company!", httpStatus.INTERNAL_SERVER_ERROR);
+  }
+};
+
+export const createCompany = async (data: CreateCompanyData): Promise<Company> => {
+  try {
+    return await createCompanyQuery(data);
+  } catch (error) {
+    if (error instanceof ApiError) throw error;
+    const err = error as Error;
+    if (err.message?.includes("duplicate key") || err.message?.includes("unique constraint")) {
+      throw new ApiError("A company with this PIB or MB already exists.", httpStatus.CONFLICT);
+    }
+    throw new ApiError("Error creating company!", httpStatus.INTERNAL_SERVER_ERROR);
+  }
+};
+
+export const updateCompany = async (data: EditCompanyData): Promise<Company> => {
+  try {
+    const existing = await getCompanyByIdQuery(data.id);
+    if (!existing) throw new ApiError("Company not found.", httpStatus.NOT_FOUND);
+    return await updateCompanyQuery(data);
+  } catch (error) {
+    if (error instanceof ApiError) throw error;
+    const err = error as Error;
+    if (err.message?.includes("duplicate key") || err.message?.includes("unique constraint")) {
+      throw new ApiError("A company with this PIB or MB already exists.", httpStatus.CONFLICT);
+    }
+    throw new ApiError("Error updating company!", httpStatus.INTERNAL_SERVER_ERROR);
+  }
+};
+
+export const deleteCompany = async (id: string): Promise<Company> => {
+  try {
+    const existing = await getCompanyByIdQuery(id);
+    if (!existing) throw new ApiError("Company not found.", httpStatus.NOT_FOUND);
+    return await deleteCompanyQuery(id);
+  } catch (error) {
+    if (error instanceof ApiError) throw error;
+    throw new ApiError("Error deleting company!", httpStatus.INTERNAL_SERVER_ERROR);
+  }
+};

--- a/deploy/backend/src/service/company.service.types.ts
+++ b/deploy/backend/src/service/company.service.types.ts
@@ -1,0 +1,23 @@
+export type CompanyEmail = { address: string; isPrimary: boolean };
+
+export type Company = {
+  id: string;
+  name: string;
+  pib: string;
+  mb: string;
+  address: string | null;
+  phones: string[];
+  emails: CompanyEmail[];
+  ownerInfo: string | null;
+  representative: string | null;
+  isOwnCompany: boolean;
+  isCustomer: boolean;
+  isSupplier: boolean;
+  notes: string | null;
+  logo: string | null;
+  createdAt?: Date;
+  updatedAt?: Date;
+};
+
+export type CreateCompanyData = Omit<Company, "id" | "createdAt" | "updatedAt">;
+export type EditCompanyData = Omit<Company, "createdAt" | "updatedAt">;

--- a/deploy/backend/src/service/index.ts
+++ b/deploy/backend/src/service/index.ts
@@ -19,3 +19,4 @@ export * as itemService from "./item.service";
 export * as bomLineService from "./bomLine.service";
 export * as packagingUnitService from "./packagingUnit.service";
 export * as itemPackagingService from "./itemPackaging.service";
+export * as companyService from "./company.service";

--- a/deploy/backend/src/service/mold.service.ts
+++ b/deploy/backend/src/service/mold.service.ts
@@ -7,6 +7,7 @@ import {
   getAllMoldsQuery,
   getMoldByIdQuery,
   getMoldMountedOnMachineQuery,
+  getMoldsByCompanyIdQuery,
   getTotalMoldsCountQuery,
   updateMoldQuery,
 } from "../models/mold.model";
@@ -97,6 +98,14 @@ export const updateMold = async (data: EditMoldData): Promise<Mold> => {
       );
     }
     throw new ApiError("Error while updating mold!", httpStatus.INTERNAL_SERVER_ERROR);
+  }
+};
+
+export const getMoldsByCompanyId = async (companyId: string): Promise<Mold[]> => {
+  try {
+    return await getMoldsByCompanyIdQuery(companyId);
+  } catch (error) {
+    throw new ApiError("Error while fetching molds by company!", httpStatus.INTERNAL_SERVER_ERROR);
   }
 };
 

--- a/deploy/backend/src/service/mold.service.types.ts
+++ b/deploy/backend/src/service/mold.service.types.ts
@@ -29,6 +29,8 @@ export type Mold = {
   currentMachineId: string | null;
   currentMachineName?: string | null;
   currentMachineNumber?: number | null;
+  ownedByCompanyId: string | null;
+  ownedByCompanyName?: string | null;
   createdAt?: Date;
   updatedAt?: Date;
 };

--- a/deploy/backend/src/shared/joi/company.schema.ts
+++ b/deploy/backend/src/shared/joi/company.schema.ts
@@ -1,0 +1,38 @@
+import Joi from "joi";
+
+const emailEntrySchema = Joi.object({
+  address: Joi.string().email({ tlds: { allow: false } }).required(),
+  isPrimary: Joi.boolean().required(),
+});
+
+export const CreateCompanySchema = Joi.object({
+  name: Joi.string().max(255).required(),
+  pib: Joi.string().max(20).required(),
+  mb: Joi.string().max(20).required(),
+  address: Joi.string().max(255).optional().allow("", null),
+  phones: Joi.array().items(Joi.string()).optional().default([]),
+  emails: Joi.array().items(emailEntrySchema).optional().default([]),
+  ownerInfo: Joi.string().max(255).optional().allow("", null),
+  representative: Joi.string().max(255).optional().allow("", null),
+  isOwnCompany: Joi.boolean().optional().default(false),
+  isCustomer: Joi.boolean().optional().default(false),
+  isSupplier: Joi.boolean().optional().default(false),
+  notes: Joi.string().optional().allow("", null),
+  logo: Joi.string().optional().allow("", null),
+});
+
+export const UpdateCompanySchema = Joi.object({
+  name: Joi.string().max(255).optional(),
+  pib: Joi.string().max(20).optional(),
+  mb: Joi.string().max(20).optional(),
+  address: Joi.string().max(255).optional().allow("", null),
+  phones: Joi.array().items(Joi.string()).optional(),
+  emails: Joi.array().items(emailEntrySchema).optional(),
+  ownerInfo: Joi.string().max(255).optional().allow("", null),
+  representative: Joi.string().max(255).optional().allow("", null),
+  isOwnCompany: Joi.boolean().optional(),
+  isCustomer: Joi.boolean().optional(),
+  isSupplier: Joi.boolean().optional(),
+  notes: Joi.string().optional().allow("", null),
+  logo: Joi.string().optional().allow("", null),
+});

--- a/deploy/backend/src/shared/joi/mold.schema.ts
+++ b/deploy/backend/src/shared/joi/mold.schema.ts
@@ -32,6 +32,7 @@ export const CreateMoldSchema = Joi.object({
   serviceCategory: Joi.string().valid("S-1", "S-2", "S-3", "S-4").optional().allow(null),
   notes: Joi.string().optional().allow("", null),
   currentMachineId: Joi.string().uuid().optional().allow(null),
+  ownedByCompanyId: Joi.string().uuid().optional().allow(null),
 });
 
 export const UpdateMoldSchema = Joi.object({
@@ -53,6 +54,7 @@ export const UpdateMoldSchema = Joi.object({
   serviceCategory: Joi.string().valid("S-1", "S-2", "S-3", "S-4").optional().allow(null),
   notes: Joi.string().optional().allow("", null),
   currentMachineId: Joi.string().uuid().optional().allow(null),
+  ownedByCompanyId: Joi.string().uuid().optional().allow(null),
   createdAt: Joi.date().iso().optional(),
   updatedAt: Joi.date().iso().optional(),
 });

--- a/deploy/frontend/src/App.tsx
+++ b/deploy/frontend/src/App.tsx
@@ -23,6 +23,10 @@ import ItemPage from '@/scenes/itemManagement/item/ItemPage.tsx';
 import PackagingUnitList from '@/scenes/itemManagement/packagingUnit/index.tsx';
 import AddPackagingUnit from '@/scenes/itemManagement/packagingUnit/addPackagingUnit.tsx';
 import EditPackagingUnit from '@/scenes/itemManagement/packagingUnit/editPackagingUnit.tsx';
+import CompanyList from '@/scenes/companyManagement/index.tsx';
+import AddCompany from '@/scenes/companyManagement/addCompany.tsx';
+import EditCompany from '@/scenes/companyManagement/editCompany.tsx';
+import CompanyPage from '@/scenes/companyManagement/CompanyPage.tsx';
 import JobPositionCategoryList from '@/scenes/jobPositionCategoryManagement';
 import AddJobPositionCategory from '@/scenes/jobPositionCategoryManagement/AddJobPositionCategory.tsx';
 import EditJobPositionCategory from '@/scenes/jobPositionCategoryManagement/EditJobPositionCategory.tsx';
@@ -401,6 +405,38 @@ function App() {
                 element={
                   <ProtectedRoute>
                     <EditPackagingUnit />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/company"
+                element={
+                  <ProtectedRoute>
+                    <CompanyList />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/addCompany"
+                element={
+                  <ProtectedRoute>
+                    <AddCompany />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/editCompany/:id"
+                element={
+                  <ProtectedRoute>
+                    <EditCompany />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/company/:id"
+                element={
+                  <ProtectedRoute>
+                    <CompanyPage />
                   </ProtectedRoute>
                 }
               />

--- a/deploy/frontend/src/locales/en.json
+++ b/deploy/frontend/src/locales/en.json
@@ -369,6 +369,8 @@
   },
   "sidebar": {
     "dashboard": "Dashboard",
+    "companyManagement": "Company Management",
+    "companies": "Companies",
     "personManagement": "Person Management",
     "persons": "Persons",
     "jobPositions": "Job Positions",
@@ -566,6 +568,8 @@
       "sectionDocuments": "Documents",
       "currentMachine": "Currently mounted on",
       "notMounted": "Not mounted",
+      "ownedByCompany": "Owned by",
+      "noOwner": "Factory owned",
       "sectionCompatibleMachines": "Compatible Machines",
       "addCompatibleMachine": "Add Machine",
       "noCompatibleMachines": "No compatible machines assigned",
@@ -715,6 +719,60 @@
       "description": "Description",
       "picture": "Picture",
       "uploadPicture": "Upload Picture"
+    }
+  },
+  "company": {
+    "list": {
+      "title": "COMPANIES",
+      "subtitle": "Manage own companies, customers and suppliers",
+      "add": "Add Company",
+      "name": "Name",
+      "pib": "PIB",
+      "mb": "MB",
+      "type": "Type",
+      "actions": "Actions",
+      "deleteTitle": "Delete Company",
+      "deleteDescription": "Are you sure you want to delete company \"{{name}}\"?",
+      "filterAll": "All",
+      "filterOwn": "Own",
+      "filterCustomer": "Customer",
+      "filterSupplier": "Supplier"
+    },
+    "form": {
+      "addTitle": "Add Company",
+      "editTitle": "Edit Company",
+      "addSubmit": "Add",
+      "editSubmit": "Update",
+      "cancel": "Cancel",
+      "name": "Full Name",
+      "pib": "PIB",
+      "mb": "MB (Registration Number)",
+      "address": "Address",
+      "phones": "Phone Numbers",
+      "addPhone": "Add Phone",
+      "emails": "Email Addresses",
+      "addEmail": "Add Email",
+      "primaryEmail": "Primary",
+      "ownerInfo": "Owner",
+      "representative": "Representative",
+      "isOwnCompany": "Own Company",
+      "isCustomer": "Customer",
+      "isSupplier": "Supplier",
+      "notes": "Notes",
+      "rolesSection": "Company Type",
+      "contactSection": "Contact Information",
+      "legalSection": "Legal Information",
+      "uploadLogo": "Upload Logo",
+      "removeLogo": "Remove"
+    },
+    "badge": {
+      "own": "Own",
+      "customer": "Customer",
+      "supplier": "Supplier"
+    },
+    "detail": {
+      "ownedMolds": "Owned Molds",
+      "ownedMoldsEmpty": "No molds owned by this company"
     }
   },
   "dataGrid": {

--- a/deploy/frontend/src/locales/sr.json
+++ b/deploy/frontend/src/locales/sr.json
@@ -369,6 +369,8 @@
   },
   "sidebar": {
     "dashboard": "Početna",
+    "companyManagement": "Upravljanje firmama",
+    "companies": "Firme",
     "personManagement": "Upravljanje zaposlenima",
     "persons": "Zaposleni",
     "jobPositions": "Radna mesta",
@@ -566,6 +568,8 @@
       "sectionDocuments": "Dokumenta",
       "currentMachine": "Trenutno montiran na",
       "notMounted": "Nije montiran",
+      "ownedByCompany": "Vlasnik kalupa",
+      "noOwner": "Vlasništvo fabrike",
       "sectionCompatibleMachines": "Kompatibilne mašine",
       "addCompatibleMachine": "Dodaj mašinu",
       "noCompatibleMachines": "Nema dodeljenih kompatibilnih mašina",
@@ -715,6 +719,60 @@
       "description": "Opis",
       "picture": "Fotografija",
       "uploadPicture": "Postavi fotografiju"
+    }
+  },
+  "company": {
+    "list": {
+      "title": "FIRME",
+      "subtitle": "Upravljanje matičnim firmama, kupcima i dobavljačima",
+      "add": "Dodaj firmu",
+      "name": "Naziv",
+      "pib": "PIB",
+      "mb": "MB",
+      "type": "Tip",
+      "actions": "Akcije",
+      "deleteTitle": "Obriši firmu",
+      "deleteDescription": "Da li ste sigurni da želite obrisati firmu \"{{name}}\"?",
+      "filterAll": "Sve",
+      "filterOwn": "Matična",
+      "filterCustomer": "Kupac",
+      "filterSupplier": "Dobavljač"
+    },
+    "form": {
+      "addTitle": "Dodaj firmu",
+      "editTitle": "Uredi firmu",
+      "addSubmit": "Dodaj",
+      "editSubmit": "Ažuriraj",
+      "cancel": "Otkaži",
+      "name": "Puni naziv",
+      "pib": "PIB",
+      "mb": "MB (Matični broj)",
+      "address": "Adresa",
+      "phones": "Brojevi telefona",
+      "addPhone": "Dodaj telefon",
+      "emails": "Email adrese",
+      "addEmail": "Dodaj email",
+      "primaryEmail": "Glavni",
+      "ownerInfo": "Vlasnik",
+      "representative": "Zastupnik",
+      "isOwnCompany": "Matična firma",
+      "isCustomer": "Kupac",
+      "isSupplier": "Dobavljač",
+      "notes": "Napomene",
+      "rolesSection": "Tip firme",
+      "contactSection": "Kontakt informacije",
+      "legalSection": "Pravne informacije",
+      "uploadLogo": "Postavi logo",
+      "removeLogo": "Ukloni"
+    },
+    "badge": {
+      "own": "Matična",
+      "customer": "Kupac",
+      "supplier": "Dobavljač"
+    },
+    "detail": {
+      "ownedMolds": "Kalupi u vlasništvu",
+      "ownedMoldsEmpty": "Ova firma ne poseduje nijedan kalup"
     }
   },
   "dataGrid": {

--- a/deploy/frontend/src/reusableComponents/Sidebar.tsx
+++ b/deploy/frontend/src/reusableComponents/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   TuneOutlined,
   ViewInArOutlined,
   InventoryOutlined,
+  BusinessOutlined,
 } from '@mui/icons-material';
 import {
   Box,
@@ -53,6 +54,8 @@ type SidebarProps = {
 
 const navItems: NavItem[] = [
   { textKey: 'sidebar.dashboard', path: 'dashboard', icon: <HomeOutlined />, requiresAuth: false },
+  { textKey: 'sidebar.companyManagement', path: null, icon: null, requiresAuth: true },
+  { textKey: 'sidebar.companies', path: 'company', icon: <BusinessOutlined />, requiresAuth: true },
   { textKey: 'sidebar.personManagement', path: null, icon: null, requiresAuth: true },
   { textKey: 'sidebar.persons', path: 'person', icon: <Groups2Outlined />, requiresAuth: true },
   { textKey: 'sidebar.jobPositions', path: 'jobPosition', icon: <ReceiptLongOutlined />, requiresAuth: true },

--- a/deploy/frontend/src/scenes/companyManagement/CompanyPage.tsx
+++ b/deploy/frontend/src/scenes/companyManagement/CompanyPage.tsx
@@ -1,0 +1,191 @@
+import BusinessIcon from '@mui/icons-material/Business';
+import EditIcon from '@mui/icons-material/Edit';
+import EmailIcon from '@mui/icons-material/Email';
+import PersonIcon from '@mui/icons-material/Person';
+import PhoneIcon from '@mui/icons-material/Phone';
+import StarIcon from '@mui/icons-material/Star';
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Divider,
+  Paper,
+  Stack,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import Header from '@/reusableComponents/Header';
+import { useAppDispatch } from '@/state/hooks';
+import { fetchCompanyById } from '@/state/company/company.actions';
+import { selectCompanyLoading, selectCurrentCompany } from '@/state/company/company.selectors';
+import { fetchMoldsByCompany } from '@/state/mold/mold.actions';
+import { selectMoldsByCompany } from '@/state/mold/mold.selectors';
+
+const InfoRow = ({ label, value }: { label: string; value: string | null | undefined }) => {
+  if (!value) return null;
+  return (
+    <Box display="flex" gap={1} alignItems="flex-start">
+      <Typography variant="body2" color="text.secondary" sx={{ minWidth: 160, fontWeight: 500 }}>{label}</Typography>
+      <Typography variant="body2">{value}</Typography>
+    </Box>
+  );
+};
+
+const CompanyPage = () => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const dispatch = useAppDispatch();
+
+  const company = useSelector(selectCurrentCompany);
+  const loading = useSelector(selectCompanyLoading);
+  const ownedMolds = useSelector(selectMoldsByCompany);
+
+  useEffect(() => {
+    if (id) {
+      dispatch(fetchCompanyById(id));
+      dispatch(fetchMoldsByCompany(id));
+    }
+  }, [dispatch, id]);
+
+  if (loading && !company) {
+    return <Box display="flex" justifyContent="center" alignItems="center" height="100%"><CircularProgress /></Box>;
+  }
+
+  if (!company) return null;
+
+  return (
+    <Box sx={{ px: { xs: 1, sm: 2, md: 3 }, pt: { xs: 1, sm: 2 }, pb: 2 }}>
+      <Box display="flex" justifyContent="space-between" alignItems="flex-start" mb={2} flexWrap="wrap" gap={1}>
+        <Box display="flex" alignItems="center" gap={2}>
+          {company.logo && (
+            <Box
+              component="img"
+              src={`${import.meta.env.VITE_API_URL ?? ''}${company.logo}`}
+              alt={company.name}
+              sx={{ width: 56, height: 56, borderRadius: 2, objectFit: 'contain', border: '1px solid', borderColor: 'divider' }}
+              onError={(e) => { (e.currentTarget as HTMLImageElement).onerror = null; (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
+            />
+          )}
+          <Header title={company.name} subtitle="" />
+        </Box>
+        <Button variant="contained" startIcon={<EditIcon />} onClick={() => navigate(`/editCompany/${company.id}`)}>
+          {t('company.form.editTitle')}
+        </Button>
+      </Box>
+
+      <Box display="flex" gap={1} mb={3} flexWrap="wrap">
+        {company.isOwnCompany && <Chip icon={<BusinessIcon />} label={t('company.badge.own')} color="primary" />}
+        {company.isCustomer && <Chip label={t('company.badge.customer')} color="success" />}
+        {company.isSupplier && <Chip label={t('company.badge.supplier')} color="warning" />}
+      </Box>
+
+      <Stack spacing={2}>
+        <Paper variant="outlined" sx={{ p: 3 }}>
+          <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 2, fontWeight: 600, textTransform: 'uppercase', fontSize: '0.7rem', letterSpacing: 1 }}>
+            {t('company.form.legalSection')}
+          </Typography>
+          <Stack spacing={1}>
+            <InfoRow label={t('company.form.pib')} value={company.pib} />
+            <InfoRow label={t('company.form.mb')} value={company.mb} />
+            <InfoRow label={t('company.form.address')} value={company.address} />
+            <InfoRow label={t('company.form.ownerInfo')} value={company.ownerInfo} />
+            <InfoRow label={t('company.form.representative')} value={company.representative} />
+          </Stack>
+        </Paper>
+
+        <Paper variant="outlined" sx={{ p: 3 }}>
+          <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 2, fontWeight: 600, textTransform: 'uppercase', fontSize: '0.7rem', letterSpacing: 1 }}>
+            {t('company.form.contactSection')}
+          </Typography>
+          <Stack spacing={1.5}>
+            {company.phones.length > 0 && (
+              <Box>
+                <Box display="flex" alignItems="center" gap={0.5} mb={0.5}>
+                  <PhoneIcon fontSize="small" sx={{ color: 'text.secondary' }} />
+                  <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 500 }}>{t('company.form.phones')}</Typography>
+                </Box>
+                {company.phones.map((phone, i) => (
+                  <Typography key={i} variant="body2" sx={{ ml: 3 }}>{phone}</Typography>
+                ))}
+              </Box>
+            )}
+            {company.phones.length > 0 && company.emails.length > 0 && <Divider />}
+            {company.emails.length > 0 && (
+              <Box>
+                <Box display="flex" alignItems="center" gap={0.5} mb={0.5}>
+                  <EmailIcon fontSize="small" sx={{ color: 'text.secondary' }} />
+                  <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 500 }}>{t('company.form.emails')}</Typography>
+                </Box>
+                {company.emails.map((email, i) => (
+                  <Box key={i} display="flex" alignItems="center" gap={1} sx={{ ml: 3 }}>
+                    <Typography variant="body2">{email.address}</Typography>
+                    {email.isPrimary && <StarIcon sx={{ fontSize: 14, color: theme.palette.warning.main }} />}
+                  </Box>
+                ))}
+              </Box>
+            )}
+          </Stack>
+        </Paper>
+
+        {company.notes && (
+          <Paper variant="outlined" sx={{ p: 3 }}>
+            <Box display="flex" alignItems="center" gap={0.5} mb={1}>
+              <PersonIcon fontSize="small" sx={{ color: 'text.secondary' }} />
+              <Typography variant="subtitle2" color="text.secondary" sx={{ fontWeight: 600, textTransform: 'uppercase', fontSize: '0.7rem', letterSpacing: 1 }}>
+                {t('company.form.notes')}
+              </Typography>
+            </Box>
+            <Typography variant="body2">{company.notes}</Typography>
+          </Paper>
+        )}
+
+        <Paper variant="outlined" sx={{ p: 3 }}>
+          <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 2, fontWeight: 600, textTransform: 'uppercase', fontSize: '0.7rem', letterSpacing: 1 }}>
+            {t('company.detail.ownedMolds')}
+          </Typography>
+          {ownedMolds.length === 0 ? (
+            <Typography variant="body2" color="text.disabled">{t('company.detail.ownedMoldsEmpty')}</Typography>
+          ) : (
+            <Stack spacing={1}>
+              {ownedMolds.map((mold, index) => (
+                <Box key={mold.id}>
+                  {index > 0 && <Divider sx={{ mb: 1 }} />}
+                  <Box
+                    display="flex" alignItems="center" gap={1.5} flexWrap="wrap"
+                    sx={{ cursor: 'pointer', borderRadius: 1, px: 1, py: 0.5, '&:hover': { backgroundColor: 'action.hover' } }}
+                    onClick={() => navigate(`/mold/${mold.id}`)}
+                  >
+                    <Typography variant="body2" color="text.secondary" sx={{ fontFamily: 'monospace', minWidth: 40 }}>
+                      #{mold.inventoryNumber}
+                    </Typography>
+                    <Typography variant="body2" sx={{ flexGrow: 1 }}>{mold.name}</Typography>
+                    <Chip
+                      size="small"
+                      label={t(`mold.status.${mold.status}`)}
+                      color={mold.status === 'ok' ? 'success' : mold.status === 'fault' ? 'error' : 'warning'}
+                    />
+                    {mold.currentMachineName && (
+                      <Typography variant="caption" color="text.secondary">
+                        {mold.currentMachineName}
+                      </Typography>
+                    )}
+                  </Box>
+                </Box>
+              ))}
+            </Stack>
+          )}
+        </Paper>
+      </Stack>
+    </Box>
+  );
+};
+
+export default CompanyPage;

--- a/deploy/frontend/src/scenes/companyManagement/addCompany.tsx
+++ b/deploy/frontend/src/scenes/companyManagement/addCompany.tsx
@@ -1,0 +1,284 @@
+import AddIcon from '@mui/icons-material/Add';
+import BusinessIcon from '@mui/icons-material/Business';
+import DeleteIcon from '@mui/icons-material/Delete';
+import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  CircularProgress,
+  FormControl,
+  FormControlLabel,
+  IconButton,
+  InputLabel,
+  Switch,
+  TextField,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import { useRef, useState } from 'react';
+import { Controller, useFieldArray, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+
+import { LabeledXtField } from '@/reusableComponents/LabeledТеxtField';
+import { useAppDispatch } from '@/state/hooks';
+import { addCompany, uploadCompanyLogo } from '@/state/company/company.actions';
+import { selectCompanyError, selectCompanyLoading } from '@/state/company/company.selectors';
+import { CompanyFormData, companySchema } from '@/zodValidationSchemas/company.schema';
+
+const AddCompany = () => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+
+  const loading = useSelector(selectCompanyLoading);
+  const error = useSelector(selectCompanyError);
+
+  const [logoPath, setLogoPath] = useState<string | null>(null);
+  const [logoUploading, setLogoUploading] = useState(false);
+  const logoInputRef = useRef<HTMLInputElement>(null);
+
+  const { register, handleSubmit, control, formState: { errors }, watch, setValue } = useForm<CompanyFormData>({
+    resolver: zodResolver(companySchema),
+    defaultValues: {
+      name: '', pib: '', mb: '', address: '',
+      phones: [], emails: [],
+      ownerInfo: '', representative: '',
+      isOwnCompany: false, isCustomer: false, isSupplier: false,
+      notes: '',
+    },
+  });
+
+  const { fields: phoneFields, append: appendPhone, remove: removePhone } = useFieldArray({ control, name: 'phones' as never });
+  const { fields: emailFields, append: appendEmail, remove: removeEmail } = useFieldArray({ control, name: 'emails' });
+
+  const handleLogoChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setLogoUploading(true);
+    const result = await dispatch(uploadCompanyLogo(file));
+    setLogoUploading(false);
+    if (uploadCompanyLogo.fulfilled.match(result)) setLogoPath(result.payload);
+  };
+
+  const onSubmit = async (data: CompanyFormData) => {
+    const result = await dispatch(addCompany({
+      ...data,
+      address: data.address || null,
+      ownerInfo: data.ownerInfo || null,
+      representative: data.representative || null,
+      notes: data.notes || null,
+      logo: logoPath,
+    }));
+    if (addCompany.fulfilled.match(result)) navigate('/company');
+  };
+
+  const sectionLabel = (text: string) => (
+    <Typography variant="subtitle2" color="text.secondary" sx={{ mt: 1, mb: 0.5, fontWeight: 600, textTransform: 'uppercase', fontSize: '0.7rem', letterSpacing: 1 }}>
+      {text}
+    </Typography>
+  );
+
+  const cancelSx = {
+    color: theme.palette.primary[100],
+    borderColor: theme.palette.primary[100],
+    '&:hover': { borderColor: theme.palette.primary[200], backgroundColor: theme.palette.primary[100], color: theme.palette.common.white },
+  };
+
+  const arrayLabelSx = {
+    minWidth: '220px',
+    position: 'relative' as const,
+    transform: 'none',
+    marginBottom: { xs: 1, sm: 0 },
+    whiteSpace: 'normal' as const,
+    overflow: 'visible' as const,
+    lineHeight: 1.4,
+    paddingTop: { sm: '14px' },
+  };
+
+  return (
+    <Box display="flex" justifyContent="center" alignItems="center" height="100%" sx={{ p: 2, overflow: 'hidden' }}>
+      <Box
+        component="form"
+        onSubmit={handleSubmit(onSubmit)}
+        width="100%"
+        maxWidth="1100px"
+        p={3}
+        border="1px solid"
+        borderColor="grey.300"
+        borderRadius={2}
+        boxShadow={1}
+        sx={{
+          backgroundColor: theme.palette.background.default,
+          maxHeight: '80vh',
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <Typography variant="h4" align="center" mb={1}>{t('company.form.addTitle')}</Typography>
+
+        <Box
+          sx={{
+            flex: 1,
+            overflowY: 'auto',
+            overscrollBehavior: 'contain',
+            display: 'flex',
+            flexDirection: 'column',
+            pb: 2,
+            '&::-webkit-scrollbar': { width: 8 },
+            '&::-webkit-scrollbar-thumb': { backgroundColor: theme.palette.primary.main, borderRadius: 4 },
+            '&::-webkit-scrollbar-track': { backgroundColor: theme.palette.background.default },
+          }}
+        >
+          {/* Logo */}
+          {sectionLabel(t('company.form.uploadLogo'))}
+          <FormControl fullWidth margin="normal" sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, alignItems: 'flex-start', gap: { xs: 1, sm: 2 } }}>
+            <InputLabel sx={arrayLabelSx}>{t('company.form.uploadLogo')}:</InputLabel>
+            <Box display="flex" alignItems="center" gap={2}>
+              <Box
+                sx={{
+                  width: 64, height: 64, borderRadius: 2, border: '1px solid',
+                  borderColor: 'divider', overflow: 'hidden', flexShrink: 0,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  backgroundColor: theme.palette.background.default,
+                }}
+              >
+                {logoPath ? (
+                  <Box
+                    component="img"
+                    src={`${import.meta.env.VITE_API_URL ?? ''}${logoPath}`}
+                    alt="logo"
+                    sx={{ width: '100%', height: '100%', objectFit: 'contain' }}
+                    onError={(e) => { (e.currentTarget as HTMLImageElement).onerror = null; (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
+                  />
+                ) : (
+                  <BusinessIcon sx={{ fontSize: 28, color: 'text.disabled' }} />
+                )}
+              </Box>
+              <input ref={logoInputRef} type="file" accept="image/*" style={{ display: 'none' }} onChange={handleLogoChange} />
+              <Button variant="outlined" size="small" startIcon={logoUploading ? <CircularProgress size={14} /> : <PhotoCameraIcon />} disabled={logoUploading} onClick={() => logoInputRef.current?.click()} sx={cancelSx}>
+                {t('company.form.uploadLogo')}
+              </Button>
+              {logoPath && (
+                <Button size="small" color="error" onClick={() => setLogoPath(null)}>
+                  {t('company.form.removeLogo')}
+                </Button>
+              )}
+            </Box>
+          </FormControl>
+
+          {/* Legal */}
+          {sectionLabel(t('company.form.legalSection'))}
+          <Controller name="name" control={control} render={({ field }) => (
+            <LabeledXtField id="name" label={t('company.form.name')} value={field.value ?? ''} onChange={field.onChange} error={errors.name} />
+          )} />
+          <Controller name="pib" control={control} render={({ field }) => (
+            <LabeledXtField id="pib" label={t('company.form.pib')} value={field.value ?? ''} onChange={field.onChange} error={errors.pib} />
+          )} />
+          <Controller name="mb" control={control} render={({ field }) => (
+            <LabeledXtField id="mb" label={t('company.form.mb')} value={field.value ?? ''} onChange={field.onChange} error={errors.mb} />
+          )} />
+          <Controller name="address" control={control} render={({ field }) => (
+            <LabeledXtField id="address" label={t('company.form.address')} value={field.value ?? ''} onChange={field.onChange} />
+          )} />
+          <Controller name="ownerInfo" control={control} render={({ field }) => (
+            <LabeledXtField id="ownerInfo" label={t('company.form.ownerInfo')} value={field.value ?? ''} onChange={field.onChange} />
+          )} />
+          <Controller name="representative" control={control} render={({ field }) => (
+            <LabeledXtField id="representative" label={t('company.form.representative')} value={field.value ?? ''} onChange={field.onChange} />
+          )} />
+
+          {/* Contact */}
+          {sectionLabel(t('company.form.contactSection'))}
+
+          <FormControl fullWidth margin="normal" sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, alignItems: 'flex-start', gap: { xs: 1, sm: 2 } }}>
+            <InputLabel sx={arrayLabelSx}>{t('company.form.phones')}:</InputLabel>
+            <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
+              {phoneFields.map((field, index) => (
+                <Box key={field.id} display="flex" alignItems="center" gap={1}>
+                  <TextField size="small" fullWidth {...register(`phones.${index}` as const)} placeholder="+381..." />
+                  <IconButton size="small" color="error" onClick={() => removePhone(index)}><DeleteIcon fontSize="small" /></IconButton>
+                </Box>
+              ))}
+              <Button variant="outlined" size="small" startIcon={<AddIcon />} onClick={() => appendPhone('' as never)} sx={{ alignSelf: 'flex-start', ...cancelSx }}>
+                {t('company.form.addPhone')}
+              </Button>
+            </Box>
+          </FormControl>
+
+          <FormControl fullWidth margin="normal" sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, alignItems: 'flex-start', gap: { xs: 1, sm: 2 } }}>
+            <InputLabel sx={arrayLabelSx}>{t('company.form.emails')}:</InputLabel>
+            <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
+              {emailFields.map((field, index) => (
+                <Box key={field.id} display="flex" alignItems="center" gap={1} flexWrap="wrap">
+                  <TextField
+                    size="small" sx={{ flex: 1, minWidth: 200 }}
+                    {...register(`emails.${index}.address`)}
+                    placeholder="email@example.com"
+                    error={!!errors.emails?.[index]?.address}
+                    helperText={errors.emails?.[index]?.address?.message}
+                  />
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        size="small"
+                        checked={watch(`emails.${index}.isPrimary`) ?? false}
+                        onChange={(e) => {
+                          if (e.target.checked) emailFields.forEach((_, i) => { if (i !== index) setValue(`emails.${i}.isPrimary`, false); });
+                          setValue(`emails.${index}.isPrimary`, e.target.checked);
+                        }}
+                      />
+                    }
+                    label={<Typography variant="caption">{t('company.form.primaryEmail')}</Typography>}
+                  />
+                  <IconButton size="small" color="error" onClick={() => removeEmail(index)}><DeleteIcon fontSize="small" /></IconButton>
+                </Box>
+              ))}
+              <Button variant="outlined" size="small" startIcon={<AddIcon />} onClick={() => appendEmail({ address: '', isPrimary: emailFields.length === 0 })} sx={{ alignSelf: 'flex-start', ...cancelSx }}>
+                {t('company.form.addEmail')}
+              </Button>
+            </Box>
+          </FormControl>
+
+          {/* Company type */}
+          {sectionLabel(t('company.form.rolesSection'))}
+          <Controller name="isOwnCompany" control={control} render={({ field }) => (
+            <FormControlLabel control={<Switch checked={field.value ?? false} onChange={(e) => field.onChange(e.target.checked)} />} label={t('company.form.isOwnCompany')} />
+          )} />
+          <Controller name="isCustomer" control={control} render={({ field }) => (
+            <FormControlLabel control={<Switch checked={field.value ?? false} onChange={(e) => field.onChange(e.target.checked)} />} label={t('company.form.isCustomer')} />
+          )} />
+          <Controller name="isSupplier" control={control} render={({ field }) => (
+            <FormControlLabel control={<Switch checked={field.value ?? false} onChange={(e) => field.onChange(e.target.checked)} />} label={t('company.form.isSupplier')} />
+          )} />
+
+          {/* Notes */}
+          {sectionLabel(t('company.form.notes'))}
+          <Controller name="notes" control={control} render={({ field }) => (
+            <LabeledXtField id="notes" label={t('company.form.notes')} value={field.value ?? ''} onChange={field.onChange} multiline rows={3} />
+          )} />
+        </Box>
+
+        <Box sx={{ flexShrink: 0, pt: 2, pb: 2, px: 2, borderTop: '1px solid', borderColor: 'divider', backgroundColor: theme.palette.background.default }}>
+          {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+          <Box display="flex" gap={2}>
+            <Button type="submit" variant="contained" disabled={loading} startIcon={loading ? <CircularProgress size={20} color="inherit" /> : undefined}>
+              {loading ? `${t('company.form.addSubmit')}...` : t('company.form.addSubmit')}
+            </Button>
+            <Button variant="outlined" disabled={loading} onClick={() => navigate('/company')} sx={cancelSx}>
+              {t('company.form.cancel')}
+            </Button>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default AddCompany;

--- a/deploy/frontend/src/scenes/companyManagement/editCompany.tsx
+++ b/deploy/frontend/src/scenes/companyManagement/editCompany.tsx
@@ -1,0 +1,316 @@
+import AddIcon from '@mui/icons-material/Add';
+import BusinessIcon from '@mui/icons-material/Business';
+import DeleteIcon from '@mui/icons-material/Delete';
+import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  CircularProgress,
+  FormControl,
+  FormControlLabel,
+  IconButton,
+  InputLabel,
+  Switch,
+  TextField,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import { useEffect, useRef, useState } from 'react';
+import { Controller, useFieldArray, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { LabeledXtField } from '@/reusableComponents/LabeledТеxtField';
+import { useAppDispatch } from '@/state/hooks';
+import { fetchCompanyById, updateCompany, uploadCompanyLogo } from '@/state/company/company.actions';
+import { selectCompanyError, selectCompanyLoading, selectCurrentCompany } from '@/state/company/company.selectors';
+import { CompanyFormData, companySchema } from '@/zodValidationSchemas/company.schema';
+
+const EditCompany = () => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const dispatch = useAppDispatch();
+
+  const current = useSelector(selectCurrentCompany);
+  const loading = useSelector(selectCompanyLoading);
+  const error = useSelector(selectCompanyError);
+
+  const [logoPath, setLogoPath] = useState<string | null>(null);
+  const [logoUploading, setLogoUploading] = useState(false);
+  const logoInputRef = useRef<HTMLInputElement>(null);
+
+  const { register, handleSubmit, control, reset, formState: { errors }, watch, setValue } = useForm<CompanyFormData>({
+    resolver: zodResolver(companySchema),
+    defaultValues: {
+      name: '', pib: '', mb: '', address: '',
+      phones: [], emails: [],
+      ownerInfo: '', representative: '',
+      isOwnCompany: false, isCustomer: false, isSupplier: false,
+      notes: '',
+    },
+  });
+
+  const { fields: phoneFields, append: appendPhone, remove: removePhone } = useFieldArray({ control, name: 'phones' as never });
+  const { fields: emailFields, append: appendEmail, remove: removeEmail } = useFieldArray({ control, name: 'emails' });
+
+  useEffect(() => {
+    if (id) dispatch(fetchCompanyById(id));
+  }, [dispatch, id]);
+
+  useEffect(() => {
+    if (current) {
+      reset({
+        name: current.name,
+        pib: current.pib,
+        mb: current.mb,
+        address: current.address ?? '',
+        phones: current.phones ?? [],
+        emails: current.emails ?? [],
+        ownerInfo: current.ownerInfo ?? '',
+        representative: current.representative ?? '',
+        isOwnCompany: current.isOwnCompany,
+        isCustomer: current.isCustomer,
+        isSupplier: current.isSupplier,
+        notes: current.notes ?? '',
+      });
+      setLogoPath(current.logo ?? null);
+    }
+  }, [current, reset]);
+
+  const handleLogoChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setLogoUploading(true);
+    const result = await dispatch(uploadCompanyLogo(file));
+    setLogoUploading(false);
+    if (uploadCompanyLogo.fulfilled.match(result)) setLogoPath(result.payload);
+  };
+
+  const onSubmit = async (data: CompanyFormData) => {
+    if (!id) return;
+    const result = await dispatch(updateCompany({
+      id,
+      ...data,
+      address: data.address || null,
+      ownerInfo: data.ownerInfo || null,
+      representative: data.representative || null,
+      notes: data.notes || null,
+      logo: logoPath,
+    }));
+    if (updateCompany.fulfilled.match(result)) navigate('/company');
+  };
+
+  const sectionLabel = (text: string) => (
+    <Typography variant="subtitle2" color="text.secondary" sx={{ mt: 1, mb: 0.5, fontWeight: 600, textTransform: 'uppercase', fontSize: '0.7rem', letterSpacing: 1 }}>
+      {text}
+    </Typography>
+  );
+
+  const cancelSx = {
+    color: theme.palette.primary[100],
+    borderColor: theme.palette.primary[100],
+    '&:hover': { borderColor: theme.palette.primary[200], backgroundColor: theme.palette.primary[100], color: theme.palette.common.white },
+  };
+
+  const arrayLabelSx = {
+    minWidth: '220px',
+    position: 'relative' as const,
+    transform: 'none',
+    marginBottom: { xs: 1, sm: 0 },
+    whiteSpace: 'normal' as const,
+    overflow: 'visible' as const,
+    lineHeight: 1.4,
+    paddingTop: { sm: '14px' },
+  };
+
+  if (loading && !current) {
+    return <Box display="flex" justifyContent="center" alignItems="center" height="100%"><CircularProgress /></Box>;
+  }
+
+  return (
+    <Box display="flex" justifyContent="center" alignItems="center" height="100%" sx={{ p: 2, overflow: 'hidden' }}>
+      <Box
+        component="form"
+        onSubmit={handleSubmit(onSubmit)}
+        width="100%"
+        maxWidth="1100px"
+        p={3}
+        border="1px solid"
+        borderColor="grey.300"
+        borderRadius={2}
+        boxShadow={1}
+        sx={{
+          backgroundColor: theme.palette.background.default,
+          maxHeight: '80vh',
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <Typography variant="h4" align="center" mb={1}>{t('company.form.editTitle')}</Typography>
+
+        <Box
+          sx={{
+            flex: 1,
+            overflowY: 'auto',
+            overscrollBehavior: 'contain',
+            display: 'flex',
+            flexDirection: 'column',
+            pb: 2,
+            '&::-webkit-scrollbar': { width: 8 },
+            '&::-webkit-scrollbar-thumb': { backgroundColor: theme.palette.primary.main, borderRadius: 4 },
+            '&::-webkit-scrollbar-track': { backgroundColor: theme.palette.background.default },
+          }}
+        >
+          {/* Logo */}
+          {sectionLabel(t('company.form.uploadLogo'))}
+          <FormControl fullWidth margin="normal" sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, alignItems: 'flex-start', gap: { xs: 1, sm: 2 } }}>
+            <InputLabel sx={arrayLabelSx}>{t('company.form.uploadLogo')}:</InputLabel>
+            <Box display="flex" alignItems="center" gap={2}>
+              <Box
+                sx={{
+                  width: 64, height: 64, borderRadius: 2, border: '1px solid',
+                  borderColor: 'divider', overflow: 'hidden', flexShrink: 0,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  backgroundColor: theme.palette.background.default,
+                }}
+              >
+                {logoPath ? (
+                  <Box
+                    component="img"
+                    src={`${import.meta.env.VITE_API_URL ?? ''}${logoPath}`}
+                    alt="logo"
+                    sx={{ width: '100%', height: '100%', objectFit: 'contain' }}
+                    onError={(e) => { (e.currentTarget as HTMLImageElement).onerror = null; (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
+                  />
+                ) : (
+                  <BusinessIcon sx={{ fontSize: 28, color: 'text.disabled' }} />
+                )}
+              </Box>
+              <input ref={logoInputRef} type="file" accept="image/*" style={{ display: 'none' }} onChange={handleLogoChange} />
+              <Button variant="outlined" size="small" startIcon={logoUploading ? <CircularProgress size={14} /> : <PhotoCameraIcon />} disabled={logoUploading} onClick={() => logoInputRef.current?.click()} sx={cancelSx}>
+                {t('company.form.uploadLogo')}
+              </Button>
+              {logoPath && (
+                <Button size="small" color="error" onClick={() => setLogoPath(null)}>
+                  {t('company.form.removeLogo')}
+                </Button>
+              )}
+            </Box>
+          </FormControl>
+
+          {/* Legal */}
+          {sectionLabel(t('company.form.legalSection'))}
+          <Controller name="name" control={control} render={({ field }) => (
+            <LabeledXtField id="name" label={t('company.form.name')} value={field.value ?? ''} onChange={field.onChange} error={errors.name} />
+          )} />
+          <Controller name="pib" control={control} render={({ field }) => (
+            <LabeledXtField id="pib" label={t('company.form.pib')} value={field.value ?? ''} onChange={field.onChange} error={errors.pib} />
+          )} />
+          <Controller name="mb" control={control} render={({ field }) => (
+            <LabeledXtField id="mb" label={t('company.form.mb')} value={field.value ?? ''} onChange={field.onChange} error={errors.mb} />
+          )} />
+          <Controller name="address" control={control} render={({ field }) => (
+            <LabeledXtField id="address" label={t('company.form.address')} value={field.value ?? ''} onChange={field.onChange} />
+          )} />
+          <Controller name="ownerInfo" control={control} render={({ field }) => (
+            <LabeledXtField id="ownerInfo" label={t('company.form.ownerInfo')} value={field.value ?? ''} onChange={field.onChange} />
+          )} />
+          <Controller name="representative" control={control} render={({ field }) => (
+            <LabeledXtField id="representative" label={t('company.form.representative')} value={field.value ?? ''} onChange={field.onChange} />
+          )} />
+
+          {/* Contact */}
+          {sectionLabel(t('company.form.contactSection'))}
+
+          <FormControl fullWidth margin="normal" sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, alignItems: 'flex-start', gap: { xs: 1, sm: 2 } }}>
+            <InputLabel sx={arrayLabelSx}>{t('company.form.phones')}:</InputLabel>
+            <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
+              {phoneFields.map((field, index) => (
+                <Box key={field.id} display="flex" alignItems="center" gap={1}>
+                  <TextField size="small" fullWidth {...register(`phones.${index}` as const)} placeholder="+381..." />
+                  <IconButton size="small" color="error" onClick={() => removePhone(index)}><DeleteIcon fontSize="small" /></IconButton>
+                </Box>
+              ))}
+              <Button variant="outlined" size="small" startIcon={<AddIcon />} onClick={() => appendPhone('' as never)} sx={{ alignSelf: 'flex-start', ...cancelSx }}>
+                {t('company.form.addPhone')}
+              </Button>
+            </Box>
+          </FormControl>
+
+          <FormControl fullWidth margin="normal" sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, alignItems: 'flex-start', gap: { xs: 1, sm: 2 } }}>
+            <InputLabel sx={arrayLabelSx}>{t('company.form.emails')}:</InputLabel>
+            <Box sx={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
+              {emailFields.map((field, index) => (
+                <Box key={field.id} display="flex" alignItems="center" gap={1} flexWrap="wrap">
+                  <TextField
+                    size="small" sx={{ flex: 1, minWidth: 200 }}
+                    {...register(`emails.${index}.address`)}
+                    placeholder="email@example.com"
+                    error={!!errors.emails?.[index]?.address}
+                    helperText={errors.emails?.[index]?.address?.message}
+                  />
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        size="small"
+                        checked={watch(`emails.${index}.isPrimary`) ?? false}
+                        onChange={(e) => {
+                          if (e.target.checked) emailFields.forEach((_, i) => { if (i !== index) setValue(`emails.${i}.isPrimary`, false); });
+                          setValue(`emails.${index}.isPrimary`, e.target.checked);
+                        }}
+                      />
+                    }
+                    label={<Typography variant="caption">{t('company.form.primaryEmail')}</Typography>}
+                  />
+                  <IconButton size="small" color="error" onClick={() => removeEmail(index)}><DeleteIcon fontSize="small" /></IconButton>
+                </Box>
+              ))}
+              <Button variant="outlined" size="small" startIcon={<AddIcon />} onClick={() => appendEmail({ address: '', isPrimary: emailFields.length === 0 })} sx={{ alignSelf: 'flex-start', ...cancelSx }}>
+                {t('company.form.addEmail')}
+              </Button>
+            </Box>
+          </FormControl>
+
+          {/* Company type */}
+          {sectionLabel(t('company.form.rolesSection'))}
+          <Controller name="isOwnCompany" control={control} render={({ field }) => (
+            <FormControlLabel control={<Switch checked={field.value ?? false} onChange={(e) => field.onChange(e.target.checked)} />} label={t('company.form.isOwnCompany')} />
+          )} />
+          <Controller name="isCustomer" control={control} render={({ field }) => (
+            <FormControlLabel control={<Switch checked={field.value ?? false} onChange={(e) => field.onChange(e.target.checked)} />} label={t('company.form.isCustomer')} />
+          )} />
+          <Controller name="isSupplier" control={control} render={({ field }) => (
+            <FormControlLabel control={<Switch checked={field.value ?? false} onChange={(e) => field.onChange(e.target.checked)} />} label={t('company.form.isSupplier')} />
+          )} />
+
+          {/* Notes */}
+          {sectionLabel(t('company.form.notes'))}
+          <Controller name="notes" control={control} render={({ field }) => (
+            <LabeledXtField id="notes" label={t('company.form.notes')} value={field.value ?? ''} onChange={field.onChange} multiline rows={3} />
+          )} />
+        </Box>
+
+        <Box sx={{ flexShrink: 0, pt: 2, pb: 2, px: 2, borderTop: '1px solid', borderColor: 'divider', backgroundColor: theme.palette.background.default }}>
+          {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+          <Box display="flex" gap={2}>
+            <Button type="submit" variant="contained" disabled={loading} startIcon={loading ? <CircularProgress size={20} color="inherit" /> : undefined}>
+              {loading ? `${t('company.form.editSubmit')}...` : t('company.form.editSubmit')}
+            </Button>
+            <Button variant="outlined" disabled={loading} onClick={() => navigate('/company')} sx={cancelSx}>
+              {t('company.form.cancel')}
+            </Button>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default EditCompany;

--- a/deploy/frontend/src/scenes/companyManagement/index.tsx
+++ b/deploy/frontend/src/scenes/companyManagement/index.tsx
@@ -1,0 +1,277 @@
+import AddIcon from '@mui/icons-material/Add';
+import BusinessIcon from '@mui/icons-material/Business';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  IconButton,
+  Snackbar,
+  ToggleButton,
+  ToggleButtonGroup,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
+import { DataGrid, GridRenderCellParams } from '@mui/x-data-grid';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+
+import ConfirmDialog from '@/reusableComponents/ConfirmDialog';
+import DataGridCustomToolbar from '@/reusableComponents/DataGridCustomToolbar';
+import Header from '@/reusableComponents/Header';
+import { useDataGridLocaleText } from '@/reusableComponents/useDataGridLocaleText';
+import { deleteCompany, fetchCompanies } from '@/state/company/company.actions';
+import {
+  selectCompanies,
+  selectCompanyError,
+  selectCompanyLoading,
+  selectCompanySuccess,
+  selectCompanyTotal,
+} from '@/state/company/company.selectors';
+import { clearError, clearSuccess, resetState } from '@/state/company/company.slice';
+import { Company } from '@/state/company/company.types';
+import { AppDispatch } from '@/state/store';
+
+type TypeFilter = 'all' | 'own' | 'customer' | 'supplier';
+
+const CompanyList = () => {
+  type SelectedItem = { id: string; name: string };
+
+  const { t } = useTranslation();
+  const localeText = useDataGridLocaleText();
+  const navigate = useNavigate();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const dispatch = useDispatch<AppDispatch>();
+
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(isMobile ? 10 : 50);
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState<SelectedItem | null>(null);
+  const [notification, setNotification] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
+  const [searchInput, setSearchInput] = useState('');
+  const [search, setSearch] = useState('');
+
+  const companies = useSelector(selectCompanies);
+  const loading = useSelector(selectCompanyLoading);
+  const error = useSelector(selectCompanyError);
+  const success = useSelector(selectCompanySuccess);
+  const total = useSelector(selectCompanyTotal);
+
+  useEffect(() => {
+    if (isMobile && pageSize === 50) setPageSize(10);
+  }, [isMobile, pageSize]);
+
+  useEffect(() => {
+    dispatch(fetchCompanies({ page: page + 1, limit: pageSize, search }));
+  }, [dispatch, page, pageSize, search]);
+
+  useEffect(() => {
+    if (success) {
+      setNotification({ message: success, type: 'success' });
+      dispatch(clearSuccess());
+      dispatch(fetchCompanies({ page: page + 1, limit: pageSize, search }));
+    }
+    if (error) {
+      setNotification({ message: error, type: 'error' });
+      dispatch(clearError());
+    }
+  }, [success, error, dispatch, page, pageSize, search]);
+
+  useEffect(() => () => { dispatch(resetState()); }, [dispatch]);
+
+  const handleConfirmDelete = async () => {
+    if (!selected) return;
+    setOpen(false);
+    dispatch(deleteCompany(selected.id));
+  };
+
+  const filteredCompanies = companies.filter((c) => {
+    if (typeFilter === 'own') return c.isOwnCompany;
+    if (typeFilter === 'customer') return c.isCustomer;
+    if (typeFilter === 'supplier') return c.isSupplier;
+    return true;
+  });
+
+  const renderTypeBadges = (row: Company) => (
+    <Box display="flex" gap={0.5} flexWrap="wrap">
+      {row.isOwnCompany && <Chip label={t('company.badge.own')} size="small" color="primary" />}
+      {row.isCustomer && <Chip label={t('company.badge.customer')} size="small" color="success" />}
+      {row.isSupplier && <Chip label={t('company.badge.supplier')} size="small" color="warning" />}
+    </Box>
+  );
+
+  const columns = [
+    {
+      field: 'logo',
+      headerName: '',
+      width: 52,
+      sortable: false,
+      renderCell: (params: GridRenderCellParams<Company>) => (
+        <Box display="flex" alignItems="center" justifyContent="center" width="100%" height="100%">
+          {params.row.logo ? (
+            <Box
+              component="img"
+              src={`${import.meta.env.VITE_API_URL ?? ''}${params.row.logo}`}
+              alt={params.row.name}
+              sx={{ width: 32, height: 32, borderRadius: 1, objectFit: 'contain' }}
+              onError={(e) => { (e.currentTarget as HTMLImageElement).onerror = null; (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
+            />
+          ) : (
+            <BusinessIcon sx={{ fontSize: 24, color: 'text.disabled' }} />
+          )}
+        </Box>
+      ),
+    },
+    { field: 'name', headerName: t('company.list.name'), flex: 2, minWidth: 200 },
+    { field: 'pib', headerName: t('company.list.pib'), width: 115 },
+    { field: 'mb', headerName: t('company.list.mb'), width: 110 },
+    {
+      field: 'phone',
+      headerName: t('company.form.phones'),
+      width: 140,
+      sortable: false,
+      renderCell: (params: GridRenderCellParams<Company>) =>
+        Array.isArray(params.row.phones) && params.row.phones.length > 0 ? params.row.phones[0] : '—',
+    },
+    {
+      field: 'email',
+      headerName: t('company.form.emails'),
+      flex: 1,
+      minWidth: 180,
+      sortable: false,
+      renderCell: (params: GridRenderCellParams<Company>) => {
+        const emails = params.row.emails ?? [];
+        const primary = emails.find((e) => e.isPrimary) ?? emails[0];
+        return primary ? primary.address : '—';
+      },
+    },
+    {
+      field: 'type',
+      headerName: t('company.list.type'),
+      width: 200,
+      sortable: false,
+      renderCell: (params: GridRenderCellParams<Company>) => renderTypeBadges(params.row),
+    },
+    {
+      field: 'actions',
+      headerName: t('company.list.actions'),
+      width: 110,
+      sortable: false,
+      renderCell: (params: GridRenderCellParams<Company>) => (
+        <Box>
+          <IconButton size="small" onClick={(e) => { e.stopPropagation(); navigate(`/editCompany/${params.row.id}`); }}>
+            <EditIcon fontSize="small" />
+          </IconButton>
+          <IconButton
+            size="small"
+            color="error"
+            onClick={(e) => { e.stopPropagation(); setSelected({ id: params.row.id, name: params.row.name }); setOpen(true); }}
+          >
+            <DeleteIcon fontSize="small" />
+          </IconButton>
+        </Box>
+      ),
+    },
+  ];
+
+  return (
+    <Box sx={{ px: { xs: 1, sm: 2, md: 3 }, pt: { xs: 1, sm: 2 }, pb: 1, display: 'flex', flexDirection: 'column', height: { xs: 'calc(100vh - 56px)', sm: 'calc(100vh - 64px)' } }}>
+      <Box
+        display="flex"
+        flexDirection={isMobile ? 'column' : 'row'}
+        justifyContent="space-between"
+        alignItems={isMobile ? 'flex-start' : 'center'}
+        mb={2}
+        gap={isMobile ? 2 : 0}
+      >
+        <Header title={t('company.list.title')} subtitle={t('company.list.subtitle')} />
+        <Button
+          variant="contained"
+          startIcon={<AddIcon />}
+          onClick={() => navigate('/addCompany')}
+          fullWidth={isMobile}
+          size={isMobile ? 'medium' : 'large'}
+        >
+          {t('company.list.add')}
+        </Button>
+      </Box>
+
+      <Box mb={1.5}>
+        <ToggleButtonGroup
+          value={typeFilter}
+          exclusive
+          onChange={(_, val) => { if (val) { setTypeFilter(val); setPage(0); } }}
+          size="small"
+        >
+          <ToggleButton value="all"><BusinessIcon fontSize="small" sx={{ mr: 0.5 }} />{t('company.list.filterAll')}</ToggleButton>
+          <ToggleButton value="own">{t('company.list.filterOwn')}</ToggleButton>
+          <ToggleButton value="customer">{t('company.list.filterCustomer')}</ToggleButton>
+          <ToggleButton value="supplier">{t('company.list.filterSupplier')}</ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
+
+      <Box
+        width="100%"
+        sx={{
+          flexGrow: 1,
+          minHeight: 0,
+          overflow: 'auto',
+          '& .MuiDataGrid-root': { border: 'none' },
+          '& .MuiDataGrid-cell': { borderBottom: 'none' },
+          '& .MuiDataGrid-columnHeaders': { backgroundColor: theme.palette.secondary[300], color: theme.palette.primary[600], borderBottom: 'none' },
+          '& .MuiDataGrid-virtualScroller': { backgroundColor: theme.palette.background.paper },
+          '& .MuiDataGrid-footerContainer': { backgroundColor: theme.palette.background.paper, color: theme.palette.secondary[100], borderTop: 'none' },
+          '& .MuiDataGrid-toolbarContainer .MuiButton-text': { color: `${theme.palette.secondary[200]} !important` },
+        }}
+      >
+        <DataGrid
+          loading={loading}
+          rows={filteredCompanies}
+          getRowId={(row) => row.id}
+          columns={columns}
+          onRowClick={(params) => navigate(`/company/${params.row.id}`)}
+          sx={{
+            '& .MuiDataGrid-row': { cursor: 'pointer' },
+            '& .MuiDataGrid-virtualScroller': { overflow: 'auto', scrollbarWidth: 'thin' },
+            '& .MuiDataGrid-columnHeaderTitle': { fontSize: isMobile ? '0.75rem' : '0.875rem' },
+            '& .MuiDataGrid-cellContent': { fontSize: isMobile ? '0.75rem' : '0.875rem' },
+          }}
+          rowCount={typeFilter === 'all' ? total : filteredCompanies.length}
+          rowsPerPageOptions={isMobile ? [10, 20] : [10, 20, 50]}
+          pagination
+          page={page}
+          pageSize={pageSize}
+          paginationMode={typeFilter === 'all' ? 'server' : 'client'}
+          onPageChange={setPage}
+          onPageSizeChange={setPageSize}
+          components={{ Toolbar: DataGridCustomToolbar }}
+          componentsProps={{ toolbar: { searchInput, setSearchInput, setSearch } }}
+          density="comfortable"
+          localeText={localeText}
+        />
+      </Box>
+
+      <ConfirmDialog
+        open={open}
+        title={t('company.list.deleteTitle')}
+        message={t('company.list.deleteDescription', { name: selected?.name })}
+        onConfirm={handleConfirmDelete}
+        onClose={() => setOpen(false)}
+      />
+
+      <Snackbar open={!!notification} autoHideDuration={4000} onClose={() => setNotification(null)} anchorOrigin={{ vertical: 'top', horizontal: 'right' }}>
+        <Alert severity={notification?.type} onClose={() => setNotification(null)} sx={{ width: '100%' }}>
+          {notification?.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+};
+
+export default CompanyList;

--- a/deploy/frontend/src/scenes/itemManagement/packagingUnit/addPackagingUnit.tsx
+++ b/deploy/frontend/src/scenes/itemManagement/packagingUnit/addPackagingUnit.tsx
@@ -6,26 +6,24 @@ import {
   Box,
   Button,
   CircularProgress,
+  FormControl,
   IconButton,
-  Paper,
-  Snackbar,
-  TextField,
+  InputLabel,
   Typography,
   useTheme,
 } from '@mui/material';
-import { useEffect, useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useRef, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
-import Header from '@/reusableComponents/Header';
+import { LabeledXtField } from '@/reusableComponents/LabeledТеxtField';
 import { useAppDispatch } from '@/state/hooks';
 import { uploadSingleFile } from '@/state/fileUploads/files.actions';
 import { selectLoading as selectFileLoading } from '@/state/fileUploads/files.selectors';
 import { addPackagingUnit } from '@/state/packagingUnit/packagingUnit.actions';
-import { selectPackagingUnitError, selectPackagingUnitLoading, selectPackagingUnitSuccess } from '@/state/packagingUnit/packagingUnit.selectors';
-import { clearError, clearSuccess } from '@/state/packagingUnit/packagingUnit.slice';
+import { selectPackagingUnitError, selectPackagingUnitLoading } from '@/state/packagingUnit/packagingUnit.selectors';
 import { PackagingUnitFormData, packagingUnitSchema } from '@/zodValidationSchemas/packagingUnit.schema';
 
 type PictureRef = { name: string; path: string; dateAdded: string };
@@ -38,29 +36,15 @@ const AddPackagingUnit = () => {
 
   const loading = useSelector(selectPackagingUnitLoading);
   const error = useSelector(selectPackagingUnitError);
-  const success = useSelector(selectPackagingUnitSuccess);
   const fileLoading = useSelector(selectFileLoading);
 
   const [picture, setPicture] = useState<PictureRef | null>(null);
-  const [notification, setNotification] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const { register, handleSubmit, formState: { errors } } = useForm<PackagingUnitFormData>({
+  const { handleSubmit, control, formState: { errors } } = useForm<PackagingUnitFormData>({
     resolver: zodResolver(packagingUnitSchema),
     defaultValues: { name: '', description: '' },
   });
-
-  useEffect(() => {
-    if (success) {
-      setNotification({ message: success, type: 'success' });
-      dispatch(clearSuccess());
-      setTimeout(() => navigate('/packaging-unit'), 1200);
-    }
-    if (error) {
-      setNotification({ message: error, type: 'error' });
-      dispatch(clearError());
-    }
-  }, [success, error, dispatch, navigate]);
 
   const handlePictureSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -75,100 +59,119 @@ const AddPackagingUnit = () => {
   };
 
   const onSubmit = async (data: PackagingUnitFormData) => {
-    await dispatch(addPackagingUnit({
+    const result = await dispatch(addPackagingUnit({
       name: data.name,
       description: data.description ?? null,
       picture: picture ?? null,
     }));
+    if (addPackagingUnit.fulfilled.match(result)) navigate('/packaging-unit');
+  };
+
+  const sectionLabel = (text: string) => (
+    <Typography variant="subtitle2" color="text.secondary" sx={{ mt: 1, mb: 0.5, fontWeight: 600, textTransform: 'uppercase', fontSize: '0.7rem', letterSpacing: 1 }}>
+      {text}
+    </Typography>
+  );
+
+  const cancelSx = {
+    color: theme.palette.primary[100],
+    borderColor: theme.palette.primary[100],
+    '&:hover': { borderColor: theme.palette.primary[200], backgroundColor: theme.palette.primary[100], color: theme.palette.common.white },
+  };
+
+  const arrayLabelSx = {
+    minWidth: '220px',
+    position: 'relative' as const,
+    transform: 'none',
+    marginBottom: { xs: 1, sm: 0 },
+    whiteSpace: 'normal' as const,
+    overflow: 'visible' as const,
+    lineHeight: 1.4,
+    paddingTop: { sm: '14px' },
   };
 
   return (
-    <Box sx={{ px: { xs: 1, sm: 2, md: 3 }, pt: { xs: 1, sm: 2 }, pb: 2 }}>
-      <Header title={t('packagingUnit.form.addTitle')} subtitle="" />
+    <Box display="flex" justifyContent="center" alignItems="center" height="100%" sx={{ p: 2, overflow: 'hidden' }}>
+      <Box
+        component="form"
+        onSubmit={handleSubmit(onSubmit)}
+        width="100%"
+        maxWidth="1100px"
+        p={3}
+        border="1px solid"
+        borderColor="grey.300"
+        borderRadius={2}
+        boxShadow={1}
+        sx={{
+          backgroundColor: theme.palette.background.default,
+          maxHeight: '80vh',
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <Typography variant="h4" align="center" mb={1}>{t('packagingUnit.form.addTitle')}</Typography>
 
-      <Paper variant="outlined" sx={{ p: 3, maxWidth: 600, mt: 2 }}>
-        <Box component="form" onSubmit={handleSubmit(onSubmit)} display="flex" flexDirection="column" gap={2.5}>
-          <TextField
-            label={t('packagingUnit.form.name')}
-            size="small"
-            fullWidth
-            {...register('name')}
-            error={!!errors.name}
-            helperText={errors.name?.message}
-          />
+        <Box
+          sx={{
+            flex: 1,
+            overflowY: 'auto',
+            overscrollBehavior: 'contain',
+            display: 'flex',
+            flexDirection: 'column',
+            pb: 2,
+            '&::-webkit-scrollbar': { width: 8 },
+            '&::-webkit-scrollbar-thumb': { backgroundColor: theme.palette.primary.main, borderRadius: 4 },
+            '&::-webkit-scrollbar-track': { backgroundColor: theme.palette.background.default },
+          }}
+        >
+          {sectionLabel(t('packagingUnit.form.addTitle'))}
+          <Controller name="name" control={control} render={({ field }) => (
+            <LabeledXtField id="name" label={t('packagingUnit.form.name')} value={field.value ?? ''} onChange={field.onChange} error={errors.name} />
+          )} />
+          <Controller name="description" control={control} render={({ field }) => (
+            <LabeledXtField id="description" label={t('packagingUnit.form.description')} value={field.value ?? ''} onChange={field.onChange} error={errors.description} multiline rows={3} />
+          )} />
 
-          <TextField
-            label={t('packagingUnit.form.description')}
-            size="small"
-            fullWidth
-            multiline
-            rows={3}
-            {...register('description')}
-            error={!!errors.description}
-            helperText={errors.description?.message as string | undefined}
-          />
+          {sectionLabel(t('packagingUnit.form.picture'))}
+          <FormControl fullWidth margin="normal" sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, alignItems: 'flex-start', gap: { xs: 1, sm: 2 } }}>
+            <InputLabel sx={arrayLabelSx}>{t('packagingUnit.form.picture')}:</InputLabel>
+            <Box>
+              {picture ? (
+                <Box display="flex" alignItems="center" gap={1}>
+                  <Box
+                    component="img"
+                    src={`${import.meta.env.VITE_API_URL ?? ''}${picture.path}`}
+                    alt={picture.name}
+                    sx={{ width: 80, height: 80, objectFit: 'cover', borderRadius: 1, border: `1px solid ${theme.palette.divider}` }}
+                    onError={(e) => { const img = e.target as HTMLImageElement; img.onerror = null; img.style.display = 'none'; }}
+                  />
+                  <IconButton color="error" size="small" onClick={() => setPicture(null)}>
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </Box>
+              ) : (
+                <Button variant="outlined" size="small" startIcon={fileLoading ? <CircularProgress size={16} /> : <AddPhotoAlternateIcon />} onClick={() => fileInputRef.current?.click()} disabled={fileLoading} sx={cancelSx}>
+                  {t('packagingUnit.form.uploadPicture')}
+                </Button>
+              )}
+              <input ref={fileInputRef} type="file" accept="image/*" hidden onChange={handlePictureSelect} />
+            </Box>
+          </FormControl>
+        </Box>
 
-          <Box>
-            <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1, fontWeight: 600, textTransform: 'uppercase', fontSize: '0.7rem', letterSpacing: 1 }}>
-              {t('packagingUnit.form.picture')}
-            </Typography>
-            {picture ? (
-              <Box display="flex" alignItems="center" gap={1}>
-                <Box
-                  component="img"
-                  src={`${import.meta.env.VITE_API_URL ?? ''}${picture.path}`}
-                  alt={picture.name}
-                  sx={{ width: 80, height: 80, objectFit: 'cover', borderRadius: 1, border: `1px solid ${theme.palette.divider}` }}
-                  onError={(e) => { const img = e.target as HTMLImageElement; img.onerror = null; img.style.display = 'none'; }}
-                />
-                <IconButton color="error" size="small" onClick={() => setPicture(null)}>
-                  <DeleteIcon fontSize="small" />
-                </IconButton>
-              </Box>
-            ) : (
-              <Button
-                variant="outlined"
-                size="small"
-                startIcon={fileLoading ? <CircularProgress size={16} /> : <AddPhotoAlternateIcon />}
-                onClick={() => fileInputRef.current?.click()}
-                disabled={fileLoading}
-                sx={{
-                  color: theme.palette.primary[100],
-                  borderColor: theme.palette.primary[100],
-                  '&:hover': { borderColor: theme.palette.primary[200], backgroundColor: theme.palette.primary[100], color: theme.palette.common.white },
-                }}
-              >
-                {t('packagingUnit.form.uploadPicture')}
-              </Button>
-            )}
-            <input ref={fileInputRef} type="file" accept="image/*" hidden onChange={handlePictureSelect} />
-          </Box>
-
-          <Box display="flex" gap={1} justifyContent="flex-end" pt={1}>
-            <Button
-              variant="outlined"
-              disabled={loading}
-              onClick={() => navigate('/packaging-unit')}
-              sx={{
-                color: theme.palette.primary[100],
-                borderColor: theme.palette.primary[100],
-                '&:hover': { borderColor: theme.palette.primary[200], backgroundColor: theme.palette.primary[100], color: theme.palette.common.white },
-              }}
-            >
-              {t('packagingUnit.form.cancel')}
+        <Box sx={{ flexShrink: 0, pt: 2, pb: 2, px: 2, borderTop: '1px solid', borderColor: 'divider', backgroundColor: theme.palette.background.default }}>
+          {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+          <Box display="flex" gap={2}>
+            <Button type="submit" variant="contained" disabled={loading || fileLoading} startIcon={loading ? <CircularProgress size={20} color="inherit" /> : undefined}>
+              {loading ? `${t('packagingUnit.form.addSubmit')}...` : t('packagingUnit.form.addSubmit')}
             </Button>
-            <Button type="submit" variant="contained" disabled={loading || fileLoading}>
-              {loading ? <CircularProgress size={20} /> : t('packagingUnit.form.addSubmit')}
+            <Button variant="outlined" disabled={loading} onClick={() => navigate('/packaging-unit')} sx={cancelSx}>
+              {t('packagingUnit.form.cancel')}
             </Button>
           </Box>
         </Box>
-      </Paper>
-
-      <Snackbar open={!!notification} autoHideDuration={4000} onClose={() => setNotification(null)} anchorOrigin={{ vertical: 'top', horizontal: 'right' }}>
-        <Alert severity={notification?.type} onClose={() => setNotification(null)} sx={{ width: '100%' }}>
-          {notification?.message}
-        </Alert>
-      </Snackbar>
+      </Box>
     </Box>
   );
 };

--- a/deploy/frontend/src/scenes/itemManagement/packagingUnit/editPackagingUnit.tsx
+++ b/deploy/frontend/src/scenes/itemManagement/packagingUnit/editPackagingUnit.tsx
@@ -6,25 +6,23 @@ import {
   Box,
   Button,
   CircularProgress,
+  FormControl,
   IconButton,
-  Paper,
-  Snackbar,
-  TextField,
+  InputLabel,
   Typography,
   useTheme,
 } from '@mui/material';
 import { useEffect, useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import Header from '@/reusableComponents/Header';
+import { LabeledXtField } from '@/reusableComponents/LabeledТеxtField';
 import { uploadSingleFile } from '@/state/fileUploads/files.actions';
 import { selectLoading as selectFileLoading } from '@/state/fileUploads/files.selectors';
 import { fetchPackagingUnitById, updatePackagingUnit } from '@/state/packagingUnit/packagingUnit.actions';
-import { selectCurrentPackagingUnit, selectPackagingUnitError, selectPackagingUnitLoading, selectPackagingUnitSuccess } from '@/state/packagingUnit/packagingUnit.selectors';
-import { clearError, clearSuccess } from '@/state/packagingUnit/packagingUnit.slice';
+import { selectCurrentPackagingUnit, selectPackagingUnitError, selectPackagingUnitLoading } from '@/state/packagingUnit/packagingUnit.selectors';
 import { useAppDispatch } from '@/state/hooks';
 import { PackagingUnitFormData, packagingUnitSchema } from '@/zodValidationSchemas/packagingUnit.schema';
 
@@ -40,14 +38,12 @@ const EditPackagingUnit = () => {
   const current = useSelector(selectCurrentPackagingUnit);
   const loading = useSelector(selectPackagingUnitLoading);
   const error = useSelector(selectPackagingUnitError);
-  const success = useSelector(selectPackagingUnitSuccess);
   const fileLoading = useSelector(selectFileLoading);
 
   const [picture, setPicture] = useState<PictureRef | null>(null);
-  const [notification, setNotification] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const { register, handleSubmit, reset, formState: { errors } } = useForm<PackagingUnitFormData>({
+  const { handleSubmit, control, reset, formState: { errors } } = useForm<PackagingUnitFormData>({
     resolver: zodResolver(packagingUnitSchema),
     defaultValues: { name: '', description: '' },
   });
@@ -63,18 +59,6 @@ const EditPackagingUnit = () => {
     }
   }, [current, reset]);
 
-  useEffect(() => {
-    if (success) {
-      setNotification({ message: success, type: 'success' });
-      dispatch(clearSuccess());
-      setTimeout(() => navigate('/packaging-unit'), 1200);
-    }
-    if (error) {
-      setNotification({ message: error, type: 'error' });
-      dispatch(clearError());
-    }
-  }, [success, error, dispatch, navigate]);
-
   const handlePictureSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -89,12 +73,36 @@ const EditPackagingUnit = () => {
 
   const onSubmit = async (data: PackagingUnitFormData) => {
     if (!id) return;
-    await dispatch(updatePackagingUnit({
+    const result = await dispatch(updatePackagingUnit({
       id,
       name: data.name,
       description: data.description ?? null,
       picture: picture ?? null,
     }));
+    if (updatePackagingUnit.fulfilled.match(result)) navigate('/packaging-unit');
+  };
+
+  const sectionLabel = (text: string) => (
+    <Typography variant="subtitle2" color="text.secondary" sx={{ mt: 1, mb: 0.5, fontWeight: 600, textTransform: 'uppercase', fontSize: '0.7rem', letterSpacing: 1 }}>
+      {text}
+    </Typography>
+  );
+
+  const cancelSx = {
+    color: theme.palette.primary[100],
+    borderColor: theme.palette.primary[100],
+    '&:hover': { borderColor: theme.palette.primary[200], backgroundColor: theme.palette.primary[100], color: theme.palette.common.white },
+  };
+
+  const arrayLabelSx = {
+    minWidth: '220px',
+    position: 'relative' as const,
+    transform: 'none',
+    marginBottom: { xs: 1, sm: 0 },
+    whiteSpace: 'normal' as const,
+    overflow: 'visible' as const,
+    lineHeight: 1.4,
+    paddingTop: { sm: '14px' },
   };
 
   if (loading && !current) {
@@ -102,92 +110,87 @@ const EditPackagingUnit = () => {
   }
 
   return (
-    <Box sx={{ px: { xs: 1, sm: 2, md: 3 }, pt: { xs: 1, sm: 2 }, pb: 2 }}>
-      <Header title={t('packagingUnit.form.editTitle')} subtitle="" />
+    <Box display="flex" justifyContent="center" alignItems="center" height="100%" sx={{ p: 2, overflow: 'hidden' }}>
+      <Box
+        component="form"
+        onSubmit={handleSubmit(onSubmit)}
+        width="100%"
+        maxWidth="1100px"
+        p={3}
+        border="1px solid"
+        borderColor="grey.300"
+        borderRadius={2}
+        boxShadow={1}
+        sx={{
+          backgroundColor: theme.palette.background.default,
+          maxHeight: '80vh',
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <Typography variant="h4" align="center" mb={1}>{t('packagingUnit.form.editTitle')}</Typography>
 
-      <Paper variant="outlined" sx={{ p: 3, maxWidth: 600, mt: 2 }}>
-        <Box component="form" onSubmit={handleSubmit(onSubmit)} display="flex" flexDirection="column" gap={2.5}>
-          <TextField
-            label={t('packagingUnit.form.name')}
-            size="small"
-            fullWidth
-            {...register('name')}
-            error={!!errors.name}
-            helperText={errors.name?.message}
-          />
+        <Box
+          sx={{
+            flex: 1,
+            overflowY: 'auto',
+            overscrollBehavior: 'contain',
+            display: 'flex',
+            flexDirection: 'column',
+            pb: 2,
+            '&::-webkit-scrollbar': { width: 8 },
+            '&::-webkit-scrollbar-thumb': { backgroundColor: theme.palette.primary.main, borderRadius: 4 },
+            '&::-webkit-scrollbar-track': { backgroundColor: theme.palette.background.default },
+          }}
+        >
+          {sectionLabel(t('packagingUnit.form.editTitle'))}
+          <Controller name="name" control={control} render={({ field }) => (
+            <LabeledXtField id="name" label={t('packagingUnit.form.name')} value={field.value ?? ''} onChange={field.onChange} error={errors.name} />
+          )} />
+          <Controller name="description" control={control} render={({ field }) => (
+            <LabeledXtField id="description" label={t('packagingUnit.form.description')} value={field.value ?? ''} onChange={field.onChange} error={errors.description} multiline rows={3} />
+          )} />
 
-          <TextField
-            label={t('packagingUnit.form.description')}
-            size="small"
-            fullWidth
-            multiline
-            rows={3}
-            {...register('description')}
-            error={!!errors.description}
-            helperText={errors.description?.message as string | undefined}
-          />
+          {sectionLabel(t('packagingUnit.form.picture'))}
+          <FormControl fullWidth margin="normal" sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, alignItems: 'flex-start', gap: { xs: 1, sm: 2 } }}>
+            <InputLabel sx={arrayLabelSx}>{t('packagingUnit.form.picture')}:</InputLabel>
+            <Box>
+              {picture ? (
+                <Box display="flex" alignItems="center" gap={1}>
+                  <Box
+                    component="img"
+                    src={`${import.meta.env.VITE_API_URL ?? ''}${picture.path}`}
+                    alt={picture.name}
+                    sx={{ width: 80, height: 80, objectFit: 'cover', borderRadius: 1, border: `1px solid ${theme.palette.divider}` }}
+                    onError={(e) => { const img = e.target as HTMLImageElement; img.onerror = null; img.style.display = 'none'; }}
+                  />
+                  <IconButton color="error" size="small" onClick={() => setPicture(null)}>
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </Box>
+              ) : (
+                <Button variant="outlined" size="small" startIcon={fileLoading ? <CircularProgress size={16} /> : <AddPhotoAlternateIcon />} onClick={() => fileInputRef.current?.click()} disabled={fileLoading} sx={cancelSx}>
+                  {t('packagingUnit.form.uploadPicture')}
+                </Button>
+              )}
+              <input ref={fileInputRef} type="file" accept="image/*" hidden onChange={handlePictureSelect} />
+            </Box>
+          </FormControl>
+        </Box>
 
-          <Box>
-            <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 1, fontWeight: 600, textTransform: 'uppercase', fontSize: '0.7rem', letterSpacing: 1 }}>
-              {t('packagingUnit.form.picture')}
-            </Typography>
-            {picture ? (
-              <Box display="flex" alignItems="center" gap={1}>
-                <Box
-                  component="img"
-                  src={`${import.meta.env.VITE_API_URL ?? ''}${picture.path}`}
-                  alt={picture.name}
-                  sx={{ width: 80, height: 80, objectFit: 'cover', borderRadius: 1, border: `1px solid ${theme.palette.divider}` }}
-                  onError={(e) => { const img = e.target as HTMLImageElement; img.onerror = null; img.style.display = 'none'; }}
-                />
-                <IconButton color="error" size="small" onClick={() => setPicture(null)}>
-                  <DeleteIcon fontSize="small" />
-                </IconButton>
-              </Box>
-            ) : (
-              <Button
-                variant="outlined"
-                size="small"
-                startIcon={fileLoading ? <CircularProgress size={16} /> : <AddPhotoAlternateIcon />}
-                onClick={() => fileInputRef.current?.click()}
-                disabled={fileLoading}
-                sx={{
-                  color: theme.palette.primary[100],
-                  borderColor: theme.palette.primary[100],
-                  '&:hover': { borderColor: theme.palette.primary[200], backgroundColor: theme.palette.primary[100], color: theme.palette.common.white },
-                }}
-              >
-                {t('packagingUnit.form.uploadPicture')}
-              </Button>
-            )}
-            <input ref={fileInputRef} type="file" accept="image/*" hidden onChange={handlePictureSelect} />
-          </Box>
-
-          <Box display="flex" gap={1} justifyContent="flex-end" pt={1}>
-            <Button
-              variant="outlined"
-              disabled={loading}
-              onClick={() => navigate('/packaging-unit')}
-              sx={{
-                color: theme.palette.primary[100],
-                borderColor: theme.palette.primary[100],
-                '&:hover': { borderColor: theme.palette.primary[200], backgroundColor: theme.palette.primary[100], color: theme.palette.common.white },
-              }}
-            >
-              {t('packagingUnit.form.cancel')}
+        <Box sx={{ flexShrink: 0, pt: 2, pb: 2, px: 2, borderTop: '1px solid', borderColor: 'divider', backgroundColor: theme.palette.background.default }}>
+          {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+          <Box display="flex" gap={2}>
+            <Button type="submit" variant="contained" disabled={loading || fileLoading} startIcon={loading ? <CircularProgress size={20} color="inherit" /> : undefined}>
+              {loading ? `${t('packagingUnit.form.editSubmit')}...` : t('packagingUnit.form.editSubmit')}
             </Button>
-            <Button type="submit" variant="contained" disabled={loading || fileLoading}>
-              {loading ? <CircularProgress size={20} /> : t('packagingUnit.form.editSubmit')}
+            <Button variant="outlined" disabled={loading} onClick={() => navigate('/packaging-unit')} sx={cancelSx}>
+              {t('packagingUnit.form.cancel')}
             </Button>
           </Box>
         </Box>
-      </Paper>
-
-      <Snackbar open={!!notification} autoHideDuration={4000} onClose={() => setNotification(null)} anchorOrigin={{ vertical: 'top', horizontal: 'right' }}>
-        <Alert severity={notification?.type} onClose={() => setNotification(null)} sx={{ width: '100%' }}>
-          {notification?.message}
-        </Alert>
-      </Snackbar>
+      </Box>
     </Box>
   );
 };

--- a/deploy/frontend/src/scenes/moldManagement/mold/MoldPage.tsx
+++ b/deploy/frontend/src/scenes/moldManagement/mold/MoldPage.tsx
@@ -298,6 +298,23 @@ const MoldPage = () => {
                 <Typography variant="body2" color="text.secondary">{t('mold.form.notMounted')}</Typography>
               )}
             </Box>
+            <Box display="flex" py={0.75} borderBottom="1px solid" borderColor="divider" alignItems="center">
+              <Typography variant="body2" color="text.secondary" sx={{ width: 220, flexShrink: 0 }}>
+                {t('mold.form.ownedByCompany')}
+              </Typography>
+              {mold.ownedByCompanyId && mold.ownedByCompanyName ? (
+                <Typography
+                  variant="body2"
+                  fontWeight={500}
+                  sx={{ cursor: 'pointer', color: theme.palette.secondary.main, '&:hover': { textDecoration: 'underline' } }}
+                  onClick={() => navigate(`/company/${mold.ownedByCompanyId}`)}
+                >
+                  {mold.ownedByCompanyName}
+                </Typography>
+              ) : (
+                <Typography variant="body2" color="text.secondary">{t('mold.form.noOwner')}</Typography>
+              )}
+            </Box>
           </Paper>
         </Grid>
 

--- a/deploy/frontend/src/scenes/moldManagement/mold/addMold.tsx
+++ b/deploy/frontend/src/scenes/moldManagement/mold/addMold.tsx
@@ -22,6 +22,8 @@ import ImageGallery from '@/reusableComponents/ImageGallery.tsx';
 import { LabeledXtSelect } from '@/reusableComponents/LabeledSelectField.tsx';
 import { LabeledXtField } from '@/reusableComponents/LabeledТеxtField';
 import MachineDocumentUpload from '@/reusableComponents/MachineDocumentUpload.tsx';
+import { fetchCompaniesList } from '@/state/company/company.actions';
+import { selectCompaniesList } from '@/state/company/company.selectors';
 import { fetchMachines } from '@/state/machine/machine.actions';
 import { selectMachines } from '@/state/machine/machine.selectors';
 import { addMold } from '@/state/mold/mold.actions';
@@ -44,6 +46,7 @@ const AddMold = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch<AppDispatch>();
   const machines = useSelector(selectMachines);
+  const companiesList = useSelector(selectCompaniesList);
 
   const {
     pictures,
@@ -78,6 +81,7 @@ const AddMold = () => {
 
   useEffect(() => {
     dispatch(fetchMachines({ page: 1, limit: 200, search: '', sortField: '', sortOrder: '' }));
+    dispatch(fetchCompaniesList());
   }, [dispatch]);
 
   useEffect(() => {
@@ -144,6 +148,17 @@ const AddMold = () => {
               error={fieldState.error}
               options={machines.map((m) => ({ value: m.id, label: `#${m.machineNumber} — ${m.name}` }))}
               disabledDefaultText={t('mold.form.notMounted')}
+            />
+          )} />
+          <Controller name="ownedByCompanyId" control={control} render={({ field, fieldState }) => (
+            <LabeledXtSelect
+              id="ownedByCompanyId"
+              label={t('mold.form.ownedByCompany')}
+              value={field.value ?? ''}
+              onChange={(e) => field.onChange(e.target.value || null)}
+              error={fieldState.error}
+              options={companiesList.map((c) => ({ value: c.id, label: c.name }))}
+              disabledDefaultText={t('mold.form.noOwner')}
             />
           )} />
 

--- a/deploy/frontend/src/scenes/moldManagement/mold/editMold.tsx
+++ b/deploy/frontend/src/scenes/moldManagement/mold/editMold.tsx
@@ -24,6 +24,8 @@ import { LabeledXtField } from '@/reusableComponents/LabeledТеxtField';
 import MachineDocumentUpload from '@/reusableComponents/MachineDocumentUpload.tsx';
 import { fetchMachines } from '@/state/machine/machine.actions';
 import { selectMachines } from '@/state/machine/machine.selectors';
+import { fetchCompaniesList } from '@/state/company/company.actions';
+import { selectCompaniesList } from '@/state/company/company.selectors';
 import { fetchMoldById, updateMold } from '@/state/mold/mold.actions';
 import {
   selectCurrentMold,
@@ -56,6 +58,7 @@ const EditMold = () => {
   const success = useSelector(selectMoldSuccess);
   const currentMold = useSelector(selectCurrentMold);
   const machines = useSelector(selectMachines);
+  const companiesList = useSelector(selectCompaniesList);
 
   const {
     pictures,
@@ -80,6 +83,7 @@ const EditMold = () => {
   useEffect(() => {
     if (id) dispatch(fetchMoldById(id));
     dispatch(fetchMachines({ page: 1, limit: 200, search: '', sortField: '', sortOrder: '' }));
+    dispatch(fetchCompaniesList());
   }, [dispatch, id]);
 
   useEffect(() => {
@@ -173,6 +177,17 @@ const EditMold = () => {
               error={fieldState.error}
               options={machines.map((m) => ({ value: m.id, label: `#${m.machineNumber} — ${m.name}` }))}
               disabledDefaultText={t('mold.form.notMounted')}
+            />
+          )} />
+          <Controller name="ownedByCompanyId" control={control} render={({ field, fieldState }) => (
+            <LabeledXtSelect
+              id="ownedByCompanyId"
+              label={t('mold.form.ownedByCompany')}
+              value={field.value ?? ''}
+              onChange={(e) => field.onChange(e.target.value || null)}
+              error={fieldState.error}
+              options={companiesList.map((c) => ({ value: c.id, label: c.name }))}
+              disabledDefaultText={t('mold.form.noOwner')}
             />
           )} />
 

--- a/deploy/frontend/src/state/company/company.actions.ts
+++ b/deploy/frontend/src/state/company/company.actions.ts
@@ -1,0 +1,115 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import * as Sentry from '@sentry/react';
+import { AxiosError } from 'axios';
+
+import axiosServer from '@/services/axios.service';
+import {
+  Company,
+  CompanyListItem,
+  CompanyListResponse,
+  CompanySelectListResponse,
+  CompanySingleResponse,
+  FetchCompanyParams,
+} from './company.types';
+
+type ApiErrorResponse = { error?: { message?: string }; message?: string };
+
+const extractErrorMessage = (error: unknown, fallback: string): string => {
+  Sentry.captureException(error);
+  const e = error as AxiosError<ApiErrorResponse>;
+  return e?.response?.data?.error?.message || e?.response?.data?.message || e?.message || fallback;
+};
+
+export const fetchCompanies = createAsyncThunk<CompanyListResponse, FetchCompanyParams, { rejectValue: string }>(
+  'company/fetchAll',
+  async ({ page, limit, search }, { rejectWithValue }) => {
+    try {
+      const response = await axiosServer.get('/company', { params: { page, limit, search } });
+      if (!response.data.success) return rejectWithValue(response.data.message || 'Failed to fetch companies');
+      return response.data;
+    } catch (error: unknown) {
+      return rejectWithValue(extractErrorMessage(error, 'Failed to fetch companies'));
+    }
+  },
+);
+
+export const fetchCompaniesList = createAsyncThunk<CompanyListItem[], void, { rejectValue: string }>(
+  'company/fetchList',
+  async (_, { rejectWithValue }) => {
+    try {
+      const response = await axiosServer.get<CompanySelectListResponse>('/company/list');
+      if (!response.data.success) return rejectWithValue(response.data.message || 'Failed to fetch companies list');
+      return response.data.content.companies;
+    } catch (error: unknown) {
+      return rejectWithValue(extractErrorMessage(error, 'Failed to fetch companies list'));
+    }
+  },
+);
+
+export const fetchCompanyById = createAsyncThunk<Company, string, { rejectValue: string }>(
+  'company/fetchById',
+  async (id, { rejectWithValue }) => {
+    try {
+      const response = await axiosServer.get(`/company/${id}`);
+      if (!response.data.success) return rejectWithValue(response.data.message || 'Failed to fetch company');
+      return response.data.content.company as Company;
+    } catch (error: unknown) {
+      return rejectWithValue(extractErrorMessage(error, 'Failed to fetch company'));
+    }
+  },
+);
+
+export const addCompany = createAsyncThunk<CompanySingleResponse, Omit<Company, 'id' | 'createdAt' | 'updatedAt'>, { rejectValue: string }>(
+  'company/add',
+  async (data, { rejectWithValue }) => {
+    try {
+      const response = await axiosServer.post('/company/create', data);
+      if (!response.data.success) return rejectWithValue(response.data.message || 'Failed to create company');
+      return response.data;
+    } catch (error: unknown) {
+      return rejectWithValue(extractErrorMessage(error, 'Failed to create company'));
+    }
+  },
+);
+
+export const updateCompany = createAsyncThunk<CompanySingleResponse, Company, { rejectValue: string }>(
+  'company/update',
+  async (data, { rejectWithValue }) => {
+    try {
+      const { id, ...body } = data;
+      const response = await axiosServer.put(`/company/update/${id}`, body);
+      if (!response.data.success) return rejectWithValue(response.data.message || 'Failed to update company');
+      return response.data;
+    } catch (error: unknown) {
+      return rejectWithValue(extractErrorMessage(error, 'Failed to update company'));
+    }
+  },
+);
+
+export const uploadCompanyLogo = createAsyncThunk<string, File, { rejectValue: string }>(
+  'company/uploadLogo',
+  async (file, { rejectWithValue }) => {
+    try {
+      const formData = new FormData();
+      formData.append('logo', file);
+      const response = await axiosServer.post('/company/upload-logo', formData);
+      if (!response.data.success) return rejectWithValue('Upload failed');
+      return response.data.path as string;
+    } catch (error: unknown) {
+      return rejectWithValue(extractErrorMessage(error, 'Failed to upload logo'));
+    }
+  },
+);
+
+export const deleteCompany = createAsyncThunk<CompanySingleResponse, string, { rejectValue: string }>(
+  'company/delete',
+  async (id, { rejectWithValue }) => {
+    try {
+      const response = await axiosServer.delete(`/company/delete/${id}`);
+      if (!response.data.success) return rejectWithValue(response.data.message || 'Failed to delete company');
+      return response.data;
+    } catch (error: unknown) {
+      return rejectWithValue(extractErrorMessage(error, 'Failed to delete company'));
+    }
+  },
+);

--- a/deploy/frontend/src/state/company/company.selectors.ts
+++ b/deploy/frontend/src/state/company/company.selectors.ts
@@ -1,0 +1,9 @@
+import { RootState } from '@/state/store';
+
+export const selectCompanies = (state: RootState) => state.reducer.company.companies;
+export const selectCurrentCompany = (state: RootState) => state.reducer.company.currentCompany;
+export const selectCompaniesList = (state: RootState) => state.reducer.company.companiesList;
+export const selectCompanyLoading = (state: RootState) => state.reducer.company.loading;
+export const selectCompanyError = (state: RootState) => state.reducer.company.error;
+export const selectCompanySuccess = (state: RootState) => state.reducer.company.success;
+export const selectCompanyTotal = (state: RootState) => state.reducer.company.total;

--- a/deploy/frontend/src/state/company/company.slice.ts
+++ b/deploy/frontend/src/state/company/company.slice.ts
@@ -1,0 +1,64 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+import {
+  addCompany,
+  deleteCompany,
+  fetchCompanies,
+  fetchCompaniesList,
+  fetchCompanyById,
+  updateCompany,
+} from './company.actions';
+import { CompanyState } from './company.types';
+
+const initialState: CompanyState = {
+  companies: [],
+  currentCompany: null,
+  companiesList: [],
+  loading: false,
+  error: null,
+  success: null,
+  total: 0,
+};
+
+const companySlice = createSlice({
+  name: 'company',
+  initialState,
+  reducers: {
+    clearSuccess(state) { state.success = null; },
+    clearError(state) { state.error = null; },
+    resetState() { return initialState; },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchCompanies.pending, (state) => { state.loading = true; state.error = null; })
+      .addCase(fetchCompanies.fulfilled, (state, action) => {
+        state.loading = false;
+        state.companies = action.payload.content.companies;
+        state.total = action.payload.content.pagination.total;
+      })
+      .addCase(fetchCompanies.rejected, (state, action) => { state.loading = false; state.error = action.payload || 'Failed to fetch'; })
+
+      .addCase(fetchCompaniesList.pending, (state) => { state.loading = true; state.error = null; })
+      .addCase(fetchCompaniesList.fulfilled, (state, action) => { state.loading = false; state.companiesList = action.payload; })
+      .addCase(fetchCompaniesList.rejected, (state, action) => { state.loading = false; state.error = action.payload || 'Failed to fetch'; })
+
+      .addCase(fetchCompanyById.pending, (state) => { state.loading = true; state.error = null; })
+      .addCase(fetchCompanyById.fulfilled, (state, action) => { state.loading = false; state.currentCompany = action.payload; })
+      .addCase(fetchCompanyById.rejected, (state, action) => { state.loading = false; state.error = action.payload || 'Failed to fetch'; })
+
+      .addCase(addCompany.pending, (state) => { state.loading = true; state.error = null; })
+      .addCase(addCompany.fulfilled, (state, action) => { state.loading = false; state.success = action.payload.message || 'Created'; })
+      .addCase(addCompany.rejected, (state, action) => { state.loading = false; state.error = action.payload || 'Failed to create'; })
+
+      .addCase(updateCompany.pending, (state) => { state.loading = true; state.error = null; })
+      .addCase(updateCompany.fulfilled, (state, action) => { state.loading = false; state.success = action.payload.message || 'Updated'; })
+      .addCase(updateCompany.rejected, (state, action) => { state.loading = false; state.error = action.payload || 'Failed to update'; })
+
+      .addCase(deleteCompany.pending, (state) => { state.loading = true; state.error = null; })
+      .addCase(deleteCompany.fulfilled, (state, action) => { state.loading = false; state.success = action.payload.message || 'Deleted'; })
+      .addCase(deleteCompany.rejected, (state, action) => { state.loading = false; state.error = action.payload || 'Failed to delete'; });
+  },
+});
+
+export const { clearSuccess, clearError, resetState } = companySlice.actions;
+export default companySlice.reducer;

--- a/deploy/frontend/src/state/company/company.types.ts
+++ b/deploy/frontend/src/state/company/company.types.ts
@@ -1,0 +1,43 @@
+import { ApiResponse } from '@/state/defaultResponse';
+
+export type CompanyEmail = { address: string; isPrimary: boolean };
+
+export type Company = {
+  id: string;
+  name: string;
+  pib: string;
+  mb: string;
+  address: string | null;
+  phones: string[];
+  emails: CompanyEmail[];
+  ownerInfo: string | null;
+  representative: string | null;
+  isOwnCompany: boolean;
+  isCustomer: boolean;
+  isSupplier: boolean;
+  notes: string | null;
+  logo: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type CompanyListItem = Pick<Company, 'id' | 'name'>;
+
+export type CompanySingleResponse = ApiResponse<{ company: Company }>;
+export type CompanyListResponse = ApiResponse<{
+  companies: Company[];
+  pagination: { total: number; page: number; limit: number };
+}>;
+export type CompanySelectListResponse = ApiResponse<{ companies: CompanyListItem[] }>;
+
+export type FetchCompanyParams = { page: number; limit: number; search: string };
+
+export type CompanyState = {
+  companies: Company[];
+  currentCompany: Company | null;
+  companiesList: CompanyListItem[];
+  loading: boolean;
+  error: string | null;
+  success: string | null;
+  total: number;
+};

--- a/deploy/frontend/src/state/mold/mold.actions.ts
+++ b/deploy/frontend/src/state/mold/mold.actions.ts
@@ -6,6 +6,7 @@ import {
   AddMoldFormData,
   EditMoldFormData,
   FetchMoldParams,
+  Mold,
   MoldListResponse,
   MoldSingleResponse,
 } from './mold.types';
@@ -90,6 +91,19 @@ export const updateMold = createAsyncThunk<
     return rejectWithValue(extractErrorMessage(error, 'Failed to update mold'));
   }
 });
+
+export const fetchMoldsByCompany = createAsyncThunk<Mold[], string, { rejectValue: string }>(
+  'mold/fetchByCompany',
+  async (companyId, { rejectWithValue }) => {
+    try {
+      const response = await axiosServer.get(`/mold/by-company/${companyId}`);
+      if (!response.data.success) return rejectWithValue(response.data.message || 'Failed to fetch molds');
+      return response.data.content.molds as Mold[];
+    } catch (error: unknown) {
+      return rejectWithValue(extractErrorMessage(error, 'Failed to fetch molds by company'));
+    }
+  },
+);
 
 export const deleteMold = createAsyncThunk<
   MoldSingleResponse,

--- a/deploy/frontend/src/state/mold/mold.selectors.ts
+++ b/deploy/frontend/src/state/mold/mold.selectors.ts
@@ -6,3 +6,4 @@ export const selectMoldLoading = (state: RootState) => state.reducer.mold.loadin
 export const selectMoldError = (state: RootState) => state.reducer.mold.error;
 export const selectMoldSuccess = (state: RootState) => state.reducer.mold.success;
 export const selectMoldTotal = (state: RootState) => state.reducer.mold.total;
+export const selectMoldsByCompany = (state: RootState) => state.reducer.mold.moldsByCompany;

--- a/deploy/frontend/src/state/mold/mold.slice.ts
+++ b/deploy/frontend/src/state/mold/mold.slice.ts
@@ -1,11 +1,12 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-import { addMold, deleteMold, fetchMoldById, fetchMolds, updateMold } from './mold.actions';
+import { addMold, deleteMold, fetchMoldById, fetchMolds, fetchMoldsByCompany, updateMold } from './mold.actions';
 import { MoldState } from './mold.types';
 
 const initialState: MoldState = {
   currentMold: null,
   molds: [],
+  moldsByCompany: [],
   loading: false,
   error: null,
   success: null,
@@ -47,6 +48,10 @@ const moldSlice = createSlice({
       .addCase(updateMold.pending, (state) => { state.loading = true; state.error = null; })
       .addCase(updateMold.fulfilled, (state, action) => { state.loading = false; state.success = action.payload.message || 'Mold updated successfully'; })
       .addCase(updateMold.rejected, (state, action) => { state.loading = false; state.error = action.payload || 'Failed to update mold'; })
+
+      .addCase(fetchMoldsByCompany.pending, (state) => { state.loading = true; state.error = null; })
+      .addCase(fetchMoldsByCompany.fulfilled, (state, action) => { state.loading = false; state.moldsByCompany = action.payload; })
+      .addCase(fetchMoldsByCompany.rejected, (state, action) => { state.loading = false; state.error = action.payload || 'Failed to fetch molds'; })
 
       .addCase(deleteMold.pending, (state) => { state.loading = true; state.error = null; })
       .addCase(deleteMold.fulfilled, (state, action) => { state.loading = false; state.success = action.payload.message || 'Mold deleted successfully'; })

--- a/deploy/frontend/src/state/mold/mold.types.ts
+++ b/deploy/frontend/src/state/mold/mold.types.ts
@@ -6,6 +6,7 @@ import { moldSchema } from '@/zodValidationSchemas/mold.schema.ts';
 export type Mold = z.infer<typeof moldSchema> & {
   currentMachineName?: string | null;
   currentMachineNumber?: number | null;
+  ownedByCompanyName?: string | null;
 };
 
 export type AddMoldFormData = Omit<Mold, 'id' | 'createdAt' | 'updatedAt'>;
@@ -26,6 +27,7 @@ export type MoldListResponse = ApiResponse<{
 export type MoldState = {
   currentMold: EditMoldFormData | null;
   molds: Mold[];
+  moldsByCompany: Mold[];
   loading: boolean;
   error: string | null;
   success: string | null;

--- a/deploy/frontend/src/state/reducer.ts
+++ b/deploy/frontend/src/state/reducer.ts
@@ -20,6 +20,7 @@ import moldSlice from '@/state/mold/mold.slice.ts';
 import moldMachineCompatibilitySlice from '@/state/moldMachineCompatibility/moldMachineCompatibility.slice.ts';
 import itemSlice from '@/state/item/item.slice.ts';
 import packagingUnitSlice from '@/state/packagingUnit/packagingUnit.slice.ts';
+import companySlice from '@/state/company/company.slice.ts';
 
 const reducer = combineReducers({
   theme: themeSlice,
@@ -41,6 +42,7 @@ const reducer = combineReducers({
   moldMachineCompatibility: moldMachineCompatibilitySlice,
   item: itemSlice,
   packagingUnit: packagingUnitSlice,
+  company: companySlice,
 });
 
 export default { reducer };

--- a/deploy/frontend/src/zodValidationSchemas/company.schema.ts
+++ b/deploy/frontend/src/zodValidationSchemas/company.schema.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const companyEmailSchema = z.object({
+  address: z.string().email('Invalid email address'),
+  isPrimary: z.boolean(),
+});
+
+export const companySchema = z.object({
+  name: z.string().min(1, 'Name is required').max(255),
+  pib: z.string().min(1, 'PIB is required').max(20),
+  mb: z.string().min(1, 'MB is required').max(20),
+  address: z.string().max(255).optional().nullable(),
+  phones: z.array(z.string()).default([]),
+  emails: z.array(companyEmailSchema).default([]),
+  ownerInfo: z.string().max(255).optional().nullable(),
+  representative: z.string().max(255).optional().nullable(),
+  isOwnCompany: z.boolean().default(false),
+  isCustomer: z.boolean().default(false),
+  isSupplier: z.boolean().default(false),
+  notes: z.string().optional().nullable(),
+});
+
+export type CompanyFormData = z.infer<typeof companySchema>;

--- a/deploy/frontend/src/zodValidationSchemas/mold.schema.ts
+++ b/deploy/frontend/src/zodValidationSchemas/mold.schema.ts
@@ -41,6 +41,7 @@ export const moldSchema = z.object({
   serviceCategory: z.enum(['S-1', 'S-2', 'S-3', 'S-4']).optional().nullable(),
   notes: z.string().optional().nullable(),
   currentMachineId: z.string().uuid().optional().nullable(),
+  ownedByCompanyId: z.string().uuid().optional().nullable(),
 });
 
 export type MoldSchemaType = z.infer<typeof moldSchema>;


### PR DESCRIPTION
- Company entity: migrations, seeder, full CRUD (backend + frontend), logo upload, owned-molds list on detail page
- Mold: added GET /mold/by-company/:companyId endpoint; fixed callQuery to propagate the real DB error message
- Add/edit forms for Company and PackagingUnit restyled to match machine/person layout (centered box, scrollable content, fixed bottom bar, LabeledXtField + Controller)